### PR TITLE
Refactor CloudTrail bucket policy merge

### DIFF
--- a/modules/cloudtrail/main.tf
+++ b/modules/cloudtrail/main.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "trail_bucket" {
     resources = [local.bucket_arn]
   }
 }
-data "aws_iam_policy_document" "logs_combined" {
+data "aws_iam_policy_document" "trail_write" {
   statement {
     sid     = "AWSCloudTrailWrite"
     actions = ["s3:PutObject"]
@@ -80,7 +80,8 @@ data "aws_iam_policy_document" "logs_combined" {
   }
 }
 data "aws_iam_policy_document" "logs_combined" {
-  source_json = data.aws_iam_policy_document.trail_bucket.json
+  source_json   = data.aws_iam_policy_document.trail_bucket.json
+  override_json = data.aws_iam_policy_document.trail_write.json
 
   statement {
     sid    = "AllowSSLRequestsOnly"

--- a/modules/cloudtrail/variable.tf
+++ b/modules/cloudtrail/variable.tf
@@ -1,3 +1,8 @@
+variable "trail_name" {
+  description = "CloudTrail 名"
+  type        = string
+}
+
 variable "is_organization_trail" {
   description = "組織トレイルにするか（管理アカウント or 委任管理から作成が必要）"
   type        = bool


### PR DESCRIPTION
## Summary
- rename CloudTrail write policy document and merge with trail bucket policy via `source_json`/`override_json`
- add missing `trail_name` variable to satisfy validation

## Testing
- `terraform -chdir=modules/cloudtrail validate`
- `TF_VAR_trail_name=example AWS_ACCESS_KEY_ID=foo AWS_SECRET_ACCESS_KEY=bar AWS_DEFAULT_REGION=us-east-1 terraform -chdir=modules/cloudtrail console <<'EOF'\ndata.aws_iam_policy_document.logs_combined.json\nEOF` *(fails: output `(known after apply)` due to missing AWS credentials)*


------
https://chatgpt.com/codex/tasks/task_e_68b7ab6a89b0832eb00d9d460b16c69a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CloudTrail module now requires a trail name input for configuration.
  - S3 bucket policy updated to allow CloudTrail to write logs to the designated path.
  - Policy documents are now automatically combined to apply all necessary permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->