### PR TITLE
refactor: parameterize GuardDuty features

### DIFF
--- a/Accounts/Security/main.tf
+++ b/Accounts/Security/main.tf
@@ -17,36 +17,11 @@ locals {
 resource "aws_guardduty_detector" "this" {
   enable = true
 }
-resource "aws_guardduty_detector_feature" "s3_protection" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "S3_PROTECTION"
-  status      = "ENABLED"
-}
+resource "aws_guardduty_detector_feature" "this" {
+  for_each = toset(var.guardduty_features)
 
-resource "aws_guardduty_detector_feature" "rds_login_events" {
   detector_id = aws_guardduty_detector.this.id
-  name        = "RDS_LOGIN_EVENTS"
-  status      = "ENABLED"
-}
-
-resource "aws_guardduty_detector_feature" "eks_audit_logs" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "EKS_AUDIT_LOGS"
-  status      = "ENABLED"
-}
-resource "aws_guardduty_detector_feature" "eks_runtime_monitoring" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "EKS_RUNTIME_MONITORING"
-  status      = "ENABLED"
-}
-resource "aws_guardduty_detector_feature" "lambda_network_logs" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "LAMBDA_NETWORK_LOGS"
-  status      = "ENABLED"
-}
-resource "aws_guardduty_detector_feature" "ebs_malware_protection" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "EBS_MALWARE_PROTECTION"
+  name        = each.value
   status      = "ENABLED"
 }
 
@@ -55,44 +30,11 @@ resource "aws_guardduty_organization_configuration" "this" {
   auto_enable_organization_members = "ALL"
 }
 
-resource "aws_guardduty_organization_configuration_feature" "s3_protection" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "S3_PROTECTION"
-  auto_enable = "ALL"
-  depends_on  = [aws_guardduty_organization_configuration.this]
-}
-resource "aws_guardduty_organization_configuration_feature" "rds_login_events" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "RDS_LOGIN_EVENTS"
-  auto_enable = "ALL"
-  depends_on  = [aws_guardduty_organization_configuration.this]
-}
+resource "aws_guardduty_organization_configuration_feature" "this" {
+  for_each = toset(var.guardduty_features)
 
-resource "aws_guardduty_organization_configuration_feature" "eks_audit_logs" {
   detector_id = aws_guardduty_detector.this.id
-  name        = "EKS_AUDIT_LOGS"
-  auto_enable = "ALL"
-  depends_on  = [aws_guardduty_organization_configuration.this]
-
-}
-
-resource "aws_guardduty_organization_configuration_feature" "eks_runtime_monitoring" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "EKS_RUNTIME_MONITORING"
-  auto_enable = "ALL"
-  depends_on  = [aws_guardduty_organization_configuration.this]
-}
-
-resource "aws_guardduty_organization_configuration_feature" "lambda_network_logs" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "LAMBDA_NETWORK_LOGS"
-  auto_enable = "ALL"
-  depends_on  = [aws_guardduty_organization_configuration.this]
-}
-
-resource "aws_guardduty_organization_configuration_feature" "ebs_malware_protection" {
-  detector_id = aws_guardduty_detector.this.id
-  name        = "EBS_MALWARE_PROTECTION"
+  name        = each.value
   auto_enable = "ALL"
   depends_on  = [aws_guardduty_organization_configuration.this]
 }

--- a/Accounts/Security/variable.tf
+++ b/Accounts/Security/variable.tf
@@ -33,3 +33,16 @@ variable "tags" {
   default     = {}
   description = "Common tags to apply to all resources"
 }
+
+variable "guardduty_features" {
+  type        = list(string)
+  description = "List of GuardDuty features to enable and auto-enable for the organization."
+  default = [
+    "S3_PROTECTION",
+    "RDS_LOGIN_EVENTS",
+    "EKS_AUDIT_LOGS",
+    "EKS_RUNTIME_MONITORING",
+    "LAMBDA_NETWORK_LOGS",
+    "EBS_MALWARE_PROTECTION",
+  ]
+}


### PR DESCRIPTION
## Summary
- consolidate GuardDuty detector features into for_each
- consolidate GuardDuty organization configuration features into for_each
- add guardduty_features variable for easy future expansion

## Testing
- `pre-commit run --files Accounts/Security/main.tf Accounts/Security/variable.tf`
- `terraform init -backend=false` *(fails: Duplicate data "aws_iam_policy_document" configuration)*
- `terraform validate` *(fails: Duplicate data "aws_iam_policy_document" configuration)*
- `tflint --format checkstyle`


------
https://chatgpt.com/codex/tasks/task_e_68b7ab6ebc34832eb5ce1f235e358a0e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - GuardDuty feature enablement is now configurable via a single list setting.
  - Organization-wide auto-enable is applied to the selected features.
  - Defaults include: S3 protection, RDS login events, EKS audit logs, EKS runtime monitoring, Lambda network logs, and EBS malware protection.
- Refactor
  - Consolidated multiple static GuardDuty toggles into a data-driven configuration for simpler management and scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->