### PR TITLE
Add TFLint configuration and integrate with tooling

### DIFF
--- a/.github/workflows/terraform-static-ci.yml
+++ b/.github/workflows/terraform-static-ci.yml
@@ -39,6 +39,6 @@ jobs:
               cd "${d}"
               terraform init -backend=false -input=false >/dev/null
               terraform validate -no-color
-              tflint --minimum-failure-severity=error --format=compact
+              tflint --config="$(git rev-parse --show-toplevel)/.tflint.hcl" --minimum-failure-severity=error --format=compact
             )
           done

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@ repos:
     rev: v1.100.0
     hooks:
       - id: terraform_fmt
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+          - --args=--minimum-failure-severity=error
 
 
 # python3 -m venv .venv

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,25 @@
+plugin "aws" {
+  enabled = true
+  version = "0.42.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+config {
+  call_module_type = "local"
+}
+
+rule "terraform_deprecated_interpolation" {
+  enabled  = true
+  severity = "ERROR"
+}
+
+rule "terraform_unused_declarations" {
+  enabled  = true
+  severity = "WARNING"
+}
+
+rule "aws_instance_invalid_type" {
+  enabled  = true
+  severity = "ERROR"
+}
+


### PR DESCRIPTION
## Summary
- configure TFLint with AWS plugin and core rules
- run TFLint in pre-commit and CI with shared config

## Testing
- `pre-commit run terraform_tflint --all-files` *(fails: rule aws_kms_alias_invalid_name caused undeclared variable error)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ab49b400832eb42c75accabd42c5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Terraform linting across the repo by loading a shared configuration in the static CI workflow.
  * Added a pre-commit hook to automatically run Terraform linting with enforced error severity.
  * Introduced centralized lint rules, including AWS-specific checks and validation for deprecated interpolation and unused declarations, improving consistency and early issue detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->