### PR TITLE
feat: add security config module

### DIFF
--- a/examples/security-config-minimal/.terraform.lock.hcl
+++ b/examples/security-config-minimal/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.12.0"
+  constraints = "~> 6.9"
+  hashes = [
+    "h1:8u90EMle+I3Auh4f/LPP6fEfRsAF6xCFnUZF4b7ngEs=",
+    "zh:054bcbf13c6ac9ddd2247876f82f9b56493e2f71d8c88baeec142386a395165d",
+    "zh:195489f16ad5621db2cec80be997d33060462a3b8d442c890bef3eceba34fa4d",
+    "zh:3461ef14904ab7de246296e44d24c042f3190e6bead3d7ce1d9fda63dcb0f047",
+    "zh:44517a0035996431e4127f45db5a84f53ce80730eae35629eda3101709df1e5c",
+    "zh:4b0374abaa6b9a9debed563380cc944873e4f30771dd1da7b9e812a49bf485e3",
+    "zh:531468b99465bd98a89a4ce2f1a30168dfadf6edb57f7836df8a977a2c4f9804",
+    "zh:6a95ed7b4852174aa748d3412bff3d45e4d7420d12659f981c3d9f4a1a59a35f",
+    "zh:88c2d21af1e64eed4a13dbb85590c66a519f3ecc54b72875d4bb6326f3ef84e7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a8b648470bb5df098e56b1ec5c6a39e0bbb7b496b23a19ea9f494bf48d4a122a",
+    "zh:b23fb13efdb527677db546bc92aeb2bdf64ff3f480188841f2bfdfa7d3d907c1",
+    "zh:be5858a1951ae5f5a9c388949c3e3c66a3375f684fb79b06b1d1db7a9703b18e",
+    "zh:c368e03a7c922493daf4c7348faafc45f455225815ef218b5491c46cea5f76b7",
+    "zh:e31e75d5d19b8ac08aa01be7e78207966e1faa3b82ed9fe3acfdc2d806be924c",
+    "zh:ea84182343b5fd9252a6fae41e844eed4fdc3311473a753b09f06e49ec0e7853",
+  ]
+}

--- a/examples/security-config-minimal/main.tf
+++ b/examples/security-config-minimal/main.tf
@@ -1,0 +1,79 @@
+###############################################
+# Example: security-config (minimal)
+#
+# この例は、本モジュールを最小限の入力で実行できる構成です。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+################################################
+# Variables (for example simplicity)
+################################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "環境名"
+  default     = "dev"
+}
+
+################################################
+# Data sources
+################################################
+# アカウント ID を取得してバケット名の一意性を担保
+data "aws_caller_identity" "current" {}
+
+################################################
+# Module usage
+################################################
+module "security_config" {
+  source = "../../modules/security-config"
+
+  env      = var.env
+  app_name = var.app_name
+  region   = var.region
+
+  # アカウント ID を含めてグローバル一意性を確保
+  bucket_name = "config-example-${data.aws_caller_identity.current.account_id}"
+
+  tags = {
+    Project = "minimal-gov"
+  }
+}
+
+output "aggregator_arn" {
+  value       = module.security_config.aggregator_arn
+  description = "作成された Config Aggregator の ARN"
+}
+

--- a/modules/security-config/.terraform.lock.hcl
+++ b/modules/security-config/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.12.0"
+  constraints = "~> 6.9"
+  hashes = [
+    "h1:8u90EMle+I3Auh4f/LPP6fEfRsAF6xCFnUZF4b7ngEs=",
+    "zh:054bcbf13c6ac9ddd2247876f82f9b56493e2f71d8c88baeec142386a395165d",
+    "zh:195489f16ad5621db2cec80be997d33060462a3b8d442c890bef3eceba34fa4d",
+    "zh:3461ef14904ab7de246296e44d24c042f3190e6bead3d7ce1d9fda63dcb0f047",
+    "zh:44517a0035996431e4127f45db5a84f53ce80730eae35629eda3101709df1e5c",
+    "zh:4b0374abaa6b9a9debed563380cc944873e4f30771dd1da7b9e812a49bf485e3",
+    "zh:531468b99465bd98a89a4ce2f1a30168dfadf6edb57f7836df8a977a2c4f9804",
+    "zh:6a95ed7b4852174aa748d3412bff3d45e4d7420d12659f981c3d9f4a1a59a35f",
+    "zh:88c2d21af1e64eed4a13dbb85590c66a519f3ecc54b72875d4bb6326f3ef84e7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a8b648470bb5df098e56b1ec5c6a39e0bbb7b496b23a19ea9f494bf48d4a122a",
+    "zh:b23fb13efdb527677db546bc92aeb2bdf64ff3f480188841f2bfdfa7d3d907c1",
+    "zh:be5858a1951ae5f5a9c388949c3e3c66a3375f684fb79b06b1d1db7a9703b18e",
+    "zh:c368e03a7c922493daf4c7348faafc45f455225815ef218b5491c46cea5f76b7",
+    "zh:e31e75d5d19b8ac08aa01be7e78207966e1faa3b82ed9fe3acfdc2d806be924c",
+    "zh:ea84182343b5fd9252a6fae41e844eed4fdc3311473a753b09f06e49ec0e7853",
+  ]
+}

--- a/modules/security-config/main.tf
+++ b/modules/security-config/main.tf
@@ -1,0 +1,171 @@
+###############################################
+# security-config module
+#
+# このモジュールは AWS Config を組織管理アカウントで有効化するための最小構成です。
+# 以下のリソースを作成します:
+# - (任意) AWS Config 配信用の S3 バケット（暗号化・公開ブロック済み）
+# - Config Recorder とその IAM ロール
+# - 配信チャネル (Delivery Channel) とスナップショット頻度設定
+# - 組織全体の設定を集約する Config Aggregator とその IAM ロール
+# すべてのリソースはセキュアな既定値で作成され、作成後に記録を自動開始します。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# S3 bucket for AWS Config (optional)
+#
+# セキュリティ既定値として、暗号化・バージョニング・公開ブロックを有効化。
+# create_bucket=false の場合は、既存バケット (var.bucket_name) を利用します。
+###############################################
+resource "aws_s3_bucket" "config" {
+  count  = var.create_bucket ? 1 : 0
+  bucket = var.bucket_name
+  tags   = var.tags
+}
+
+# 全ての公開アクセスをブロック
+resource "aws_s3_bucket_public_access_block" "config" {
+  count  = var.create_bucket ? 1 : 0
+  bucket = aws_s3_bucket.config[0].id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# バージョニングを有効化
+resource "aws_s3_bucket_versioning" "config" {
+  count  = var.create_bucket ? 1 : 0
+  bucket = aws_s3_bucket.config[0].id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# サーバーサイド暗号化 (SSE-S3)
+resource "aws_s3_bucket_server_side_encryption_configuration" "config" {
+  count  = var.create_bucket ? 1 : 0
+  bucket = aws_s3_bucket.config[0].id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+###############################################
+# IAM Role for Config Recorder
+###############################################
+
+# Config サービスが Assume するロール
+resource "aws_iam_role" "recorder" {
+  name               = "AWSConfigRecorderRole"
+  assume_role_policy = data.aws_iam_policy_document.recorder_assume.json
+}
+
+data "aws_iam_policy_document" "recorder_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+# 推奨マネージドポリシーをアタッチ
+resource "aws_iam_role_policy_attachment" "recorder" {
+  role       = aws_iam_role.recorder.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRole"
+}
+
+###############################################
+# Config Recorder & Delivery Channel
+###############################################
+resource "aws_config_configuration_recorder" "this" {
+  name     = "config-recorder"
+  role_arn = aws_iam_role.recorder.arn
+  recording_group {
+    all_supported                 = true
+    include_global_resource_types = true
+  }
+}
+
+resource "aws_config_delivery_channel" "this" {
+  name           = "config-delivery"
+  s3_bucket_name = var.bucket_name
+
+  snapshot_delivery_properties {
+    delivery_frequency = var.snapshot_delivery_frequency
+  }
+
+  depends_on = [aws_config_configuration_recorder.this]
+}
+
+# Recorder を有効化
+resource "aws_config_configuration_recorder_status" "this" {
+  name       = aws_config_configuration_recorder.this.name
+  is_enabled = true
+  depends_on = [aws_config_delivery_channel.this]
+}
+
+###############################################
+# IAM Role for Aggregator
+###############################################
+resource "aws_iam_role" "aggregator" {
+  name               = var.aggregator_role_name
+  assume_role_policy = data.aws_iam_policy_document.aggregator_assume.json
+}
+
+data "aws_iam_policy_document" "aggregator_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "aggregator" {
+  role       = aws_iam_role.aggregator.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSConfigRoleForOrganizations"
+}
+
+###############################################
+# Organization Config Aggregator
+###############################################
+resource "aws_config_configuration_aggregator" "this" {
+  name = "org-config-aggregator"
+  organization_aggregation_source {
+    all_regions = true
+    role_arn    = aws_iam_role.aggregator.arn
+  }
+}
+

--- a/modules/security-config/outputs.tf
+++ b/modules/security-config/outputs.tf
@@ -1,0 +1,20 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみを出力します。
+###############################################
+
+# Config Recorder 名。ステータス監視等に利用できます。
+output "recorder_name" {
+  value = aws_config_configuration_recorder.this.name
+}
+
+# Delivery Channel 名。配信設定の参照に利用します。
+output "delivery_channel_name" {
+  value = aws_config_delivery_channel.this.name
+}
+
+# Config Aggregator の ARN。跨アカウント/リージョン集約の設定で参照します。
+output "aggregator_arn" {
+  value = aws_config_configuration_aggregator.this.arn
+}
+

--- a/modules/security-config/variables.tf
+++ b/modules/security-config/variables.tf
@@ -1,0 +1,62 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "env" {
+  type        = string
+  description = "デプロイ対象の環境名 (例: dev, prod)。タグ付与およびリソース名に利用します。"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名。default_tags の Application に使用します。"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS リージョン。provider 設定およびタグに利用します。"
+}
+
+variable "bucket_name" {
+  type        = string
+  description = <<-EOT
+  AWS Config の設定履歴やスナップショットを保存する S3 バケット名。
+  create_bucket=true の場合はこの名前でバケットを新規作成します。
+  create_bucket=false の場合は既存バケット名を指定してください。
+  EOT
+}
+
+variable "create_bucket" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  true の場合、上記 bucket_name で S3 バケットを作成します。
+  false の場合、既存バケットを利用し新規作成しません。
+  EOT
+}
+
+variable "aggregator_role_name" {
+  type        = string
+  default     = "AWSConfigAggregatorRole"
+  description = <<-EOT
+  Config Aggregator が他アカウントの情報を取得するために Assume する IAM ロール名。
+  特別な理由が無い限り既定値のまま利用してください。
+  EOT
+}
+
+variable "snapshot_delivery_frequency" {
+  type        = string
+  default     = "TwentyFour_Hours"
+  description = <<-EOT
+  Config スナップショットを S3 へ配信する頻度。
+  有効な値: One_Hour, Three_Hours, Six_Hours, Twelve_Hours, TwentyFour_Hours。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "追加で付与する任意のタグ。provider の default_tags とマージされます。"
+}
+


### PR DESCRIPTION
## Summary
- add security-config module to manage AWS Config with secure defaults
- include minimal example of module usage

## Testing
- `terraform fmt modules/security-config/main.tf modules/security-config/variables.tf modules/security-config/outputs.tf examples/security-config-minimal/main.tf`
- `(module) terraform init -backend=false`
- `(module) terraform validate`
- `(example) terraform init -backend=false`
- `(example) terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0d44044e4832ebc1e4f442f90a533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a Terraform module to enable AWS Config across an organization with secure defaults (optional S3 bucket, IAM roles, recorder, delivery channel, and aggregator).
  - Exposes outputs for recorder name, delivery channel name, and aggregator ARN.
  - Adds a minimal example to run the module with basic inputs.
  - Provides configurable variables (environment, app name, region, bucket settings, snapshot frequency, and tags).

- Chores
  - Adds Terraform provider lockfiles to ensure deterministic provider installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->