### PR TITLE
feat: add security cloudtrail module

### DIFF
--- a/examples/security-cloudtrail-minimal/main.tf
+++ b/examples/security-cloudtrail-minimal/main.tf
@@ -1,0 +1,79 @@
+###############################################
+# Example: security-cloudtrail (minimal)
+#
+# この例では、組織全体の CloudTrail を最小限の入力で作成します。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Variables for example
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application タグに使用する名称"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment タグ用の値"
+  default     = "dev"
+}
+
+###############################################
+# Module invocation
+###############################################
+module "security_cloudtrail" {
+  source = "../../modules/security-cloudtrail"
+
+  trail_name = "org-trail"
+  # bucket_name を省略した場合、ct-logs-<account>-<region> が自動生成されます
+  region = var.region
+  tags = {
+    Project = "minimal-gov"
+    Env     = var.env
+  }
+}
+
+###############################################
+# Outputs
+###############################################
+output "trail_arn" {
+  description = "作成された CloudTrail トレイルの ARN"
+  value       = module.security_cloudtrail.trail_arn
+}
+
+output "bucket_name" {
+  description = "CloudTrail ログを格納する S3 バケット名"
+  value       = module.security_cloudtrail.bucket_name
+}
+

--- a/modules/security-cloudtrail/main.tf
+++ b/modules/security-cloudtrail/main.tf
@@ -1,0 +1,127 @@
+###############################################
+# Minimal Gov: Security CloudTrail module
+#
+# This module provisions the resources required for an
+# organization-wide CloudTrail setup. It creates a secure S3
+# bucket to aggregate audit logs and an Organization Trail that
+# delivers logs to that bucket.
+#
+# Resources created:
+# - S3 bucket with security best practices (versioning,
+#   encryption, public access block, ownership controls)
+# - Bucket policy permitting CloudTrail service to write logs
+# - Organization-level CloudTrail trail
+#
+# Design guidelines:
+# - Keep logic straightforward and heavily documented
+# - Enable secure defaults (encryption, public access block)
+# - Expose only necessary outputs for upstream dependencies
+###############################################
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  # Determine the bucket name. If bucket_name is provided, use it;
+  # otherwise generate a name based on account ID and region to
+  # ensure global uniqueness.
+  bucket_name = var.bucket_name != null && var.bucket_name != "" ? var.bucket_name : "ct-logs-${data.aws_caller_identity.current.account_id}-${var.region}"
+}
+
+###############################################
+# S3 bucket for CloudTrail logs
+###############################################
+resource "aws_s3_bucket" "this" {
+  bucket = local.bucket_name
+}
+
+# Enforce bucket owner preferred to avoid object ownership issues
+resource "aws_s3_bucket_ownership_controls" "this" {
+  bucket = aws_s3_bucket.this.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+# Block all public access to the bucket for security
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Enable versioning so that log files are immutable and can be recovered
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Enable server-side encryption (SSE-S3 or SSE-KMS depending on use_kms)
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = var.use_kms ? "aws:kms" : "AES256"
+      kms_master_key_id = var.use_kms ? var.kms_key_id : null
+    }
+  }
+}
+
+###############################################
+# Bucket policy: allow CloudTrail to write logs
+###############################################
+data "aws_iam_policy_document" "bucket" {
+  statement {
+    sid    = "AWSCloudTrailAclCheck"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions   = ["s3:GetBucketAcl"]
+    resources = [aws_s3_bucket.this.arn]
+  }
+
+  statement {
+    sid    = "AWSCloudTrailWrite"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions = ["s3:PutObject"]
+    # Allow CloudTrail to write logs for all accounts in the Organization
+    # under the AWSLogs/ prefix.
+    resources = ["${aws_s3_bucket.this.arn}/AWSLogs/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.bucket.json
+}
+
+###############################################
+# Organization-wide CloudTrail trail
+###############################################
+resource "aws_cloudtrail" "this" {
+  name                          = var.trail_name
+  s3_bucket_name                = aws_s3_bucket.this.bucket
+  kms_key_id                    = var.use_kms ? var.kms_key_id : null
+  is_organization_trail         = true
+  enable_logging                = var.enable_logging
+  enable_log_file_validation    = true
+  include_global_service_events = true
+  is_multi_region_trail         = true
+  depends_on                    = [aws_s3_bucket_policy.this]
+  tags                          = var.tags
+}
+

--- a/modules/security-cloudtrail/outputs.tf
+++ b/modules/security-cloudtrail/outputs.tf
@@ -1,0 +1,16 @@
+###############################################
+# Outputs
+# Only values required by callers are exposed. Comments describe
+# typical use cases for each output.
+###############################################
+
+output "trail_arn" {
+  description = "作成された CloudTrail トレイルの ARN。監視や委任設定で参照します。"
+  value       = aws_cloudtrail.this.arn
+}
+
+output "bucket_name" {
+  description = "CloudTrail ログを格納する S3 バケット名。ライフサイクル設定やアクセス許可の参照に使用します。"
+  value       = aws_s3_bucket.this.bucket
+}
+

--- a/modules/security-cloudtrail/variables.tf
+++ b/modules/security-cloudtrail/variables.tf
@@ -1,0 +1,74 @@
+###############################################
+# Variables
+# Detailed descriptions are provided for all inputs.
+###############################################
+
+variable "trail_name" {
+  type        = string
+  description = <<-EOT
+  CloudTrail のトレイル名。
+  組織全体で一意になるように、わかりやすい名称を指定してください。
+  EOT
+}
+
+variable "bucket_name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  CloudTrail ログを保存する S3 バケット名。
+
+  未指定の場合は `ct-logs-<アカウントID>-<リージョン>` 形式で自動生成され、
+  グローバルに一意な名前となります。
+  固定名を使用したい場合は明示的に指定してください。
+  EOT
+}
+
+variable "region" {
+  type        = string
+  description = <<-EOT
+  バケット名自動生成時に使用するリージョン名。
+  `bucket_name` を指定しない場合にのみ参照されます。
+  EOT
+}
+
+variable "use_kms" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  CloudTrail ログをカスタマー管理型 KMS キーで暗号化するかどうか。
+  `true` に設定した場合、kms_key_id に対象キーの ARN または ID を指定する必要があります。
+  EOT
+}
+
+variable "kms_key_id" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  CloudTrail ログ暗号化に使用する KMS キーの ARN または ID。
+  use_kms が true の場合にのみ使用されます。
+  EOT
+
+  validation {
+    condition     = !var.use_kms || (var.use_kms && var.kms_key_id != null && var.kms_key_id != "")
+    error_message = "use_kms を true にする場合、kms_key_id を指定してください。"
+  }
+}
+
+variable "enable_logging" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  作成直後から CloudTrail のログ記録を開始するかどうか。
+  一時的に無効化したい場合は false を指定します。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  CloudTrail トレイルに付与するタグのマップ。
+  バケットには自動的には伝播しないため、必要に応じて別途タグ付けしてください。
+  EOT
+}
+


### PR DESCRIPTION
## Summary
- add security-cloudtrail module for centralized org-wide CloudTrail logging
- document variables and outputs and provide minimal usage example

## Testing
- `terraform -chdir=examples/security-cloudtrail-minimal init -backend=false`
- `terraform -chdir=examples/security-cloudtrail-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0d37c42e0832ea746eb98e4846e84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduced a reusable module to deploy an organization-wide CloudTrail with secure S3 log storage (versioning, encryption, public access blocking).
  * Optional KMS encryption, configurable logging toggle, and tagging support.
  * Exposes outputs for the created trail ARN and log bucket name.

* Documentation
  * Added a minimal example demonstrating how to deploy the CloudTrail setup with common defaults, regional selection, and tagging.
  * Notes on automatic bucket naming when not provided and how to retrieve key outputs after deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->