### PR TITLE
feat: add GuardDuty organization module

### DIFF
--- a/examples/security-guardduty-minimal/main.tf
+++ b/examples/security-guardduty-minimal/main.tf
@@ -1,0 +1,79 @@
+###############################################
+# Example: security-guardduty (minimal)
+#
+# この例は、単一アカウントで GuardDuty を有効化し、
+# Organization メンバーに対しても自動的に機能を有効化する最小構成です。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+###############################################
+# Provider (repo-wide standard)
+###############################################
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Inputs for this example
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名。タグに使用します。"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "環境名（例: dev, stg, prd）。タグに使用します。"
+  default     = "dev"
+}
+
+###############################################
+# Step: Enable GuardDuty
+###############################################
+module "guardduty" {
+  source = "../../modules/security-guardduty"
+
+  # name_prefix の例として "demo" を付与
+  name_prefix         = "demo"
+  auto_enable_members = "ALL"
+
+  tags = {
+    Project = var.app_name
+    Env     = var.env
+  }
+}
+
+###############################################
+# Helpful outputs (for demo)
+###############################################
+output "detector_id" {
+  value       = module.guardduty.detector_id
+  description = "作成された GuardDuty Detector の ID"
+}
+

--- a/modules/security-guardduty/main.tf
+++ b/modules/security-guardduty/main.tf
@@ -1,0 +1,114 @@
+###############################################
+# Minimal Gov: GuardDuty module
+#
+# このモジュールは、AWS GuardDuty を組織単位で有効化するための最小構成を提供します。
+# 主な機能:
+# - GuardDuty Detector の作成と有効化
+# - 代表的な検出機能（S3、EKS、Lambda など）の有効化
+# - Organization 連携設定により、組織メンバーアカウントを自動的に GuardDuty へ参加させる
+#
+# 設計指針:
+# - ロジックは可能な限り単純化し、読みやすさを優先
+# - セキュリティ既定値として、利用可能な検出機能はすべて有効化
+# - 出力は上位モジュールが依存する最小限（Detector ID のみ）
+###############################################
+
+###############################################
+# Locals
+# - name_prefix は任意。Name タグ等で使用します。
+###############################################
+locals {
+  name_prefix = var.name_prefix != null && var.name_prefix != "" ? var.name_prefix : "guardduty"
+
+  # 追加構成が不要な GuardDuty 機能の一覧
+  basic_features = [
+    "S3_DATA_EVENTS",
+    "EKS_AUDIT_LOGS",
+    "LAMBDA_NETWORK_LOGS",
+    "RDS_LOGIN_EVENTS",
+    "EBS_MALWARE_PROTECTION",
+  ]
+}
+
+###############################################
+# GuardDuty Detector
+# - アカウント / リージョン単位で GuardDuty を有効化するリソースです。
+# - enable = true とすることで監視を開始します。
+# - Name タグには name_prefix を付与します。
+###############################################
+resource "aws_guardduty_detector" "this" {
+  enable = true
+
+  tags = merge(
+    {
+      Name = "${local.name_prefix}-detector"
+    },
+    var.tags,
+  )
+}
+
+###############################################
+# GuardDuty Detector Features（追加設定不要分）
+# - local.basic_features に定義した機能を一括で有効化します。
+# - 代表例: S3 保護、EKS Audit Logs、Lambda ネットワークログ 等
+###############################################
+resource "aws_guardduty_detector_feature" "basic" {
+  for_each    = toset(local.basic_features)
+  detector_id = aws_guardduty_detector.this.id
+  name        = each.value
+  status      = "ENABLED"
+}
+
+###############################################
+# GuardDuty Detector Feature（EKS Runtime Monitoring）
+# - EKS ランタイム監視は追加設定が必要なため個別に記述します。
+# - Add-on 管理を有効化することで、より深い検査を実施できます。
+###############################################
+resource "aws_guardduty_detector_feature" "eks_runtime_monitoring" {
+  detector_id = aws_guardduty_detector.this.id
+  name        = "EKS_RUNTIME_MONITORING"
+  status      = "ENABLED"
+
+  additional_configuration {
+    name   = "EKS_ADDON_MANAGEMENT"
+    status = "ENABLED"
+  }
+}
+
+###############################################
+# Organization Configuration
+# - GuardDuty を組織アカウントに自動有効化する設定です。
+# - auto_enable_organization_members は new/existing すべてのメンバーを対象とするかを制御します。
+###############################################
+resource "aws_guardduty_organization_configuration" "this" {
+  detector_id                      = aws_guardduty_detector.this.id
+  auto_enable_organization_members = var.auto_enable_members
+}
+
+###############################################
+# Organization Features（追加設定不要分）
+# - 上記 basic_features と同じ機能を組織メンバーにも自動有効化します。
+###############################################
+resource "aws_guardduty_organization_configuration_feature" "basic" {
+  for_each    = toset(local.basic_features)
+  detector_id = aws_guardduty_detector.this.id
+  name        = each.value
+  auto_enable = var.auto_enable_members
+}
+
+###############################################
+# Organization Feature（EKS Runtime Monitoring）
+# - EKS Runtime Monitoring を組織メンバーにも自動有効化します。
+# - additional_configuration で Add-on 管理を有効化します。
+###############################################
+resource "aws_guardduty_organization_configuration_feature" "eks_runtime_monitoring" {
+  detector_id = aws_guardduty_detector.this.id
+  name        = "EKS_RUNTIME_MONITORING"
+  auto_enable = var.auto_enable_members
+
+  additional_configuration {
+    name        = "EKS_ADDON_MANAGEMENT"
+    auto_enable = var.auto_enable_members
+  }
+}
+

--- a/modules/security-guardduty/outputs.tf
+++ b/modules/security-guardduty/outputs.tf
@@ -1,0 +1,14 @@
+###############################################
+# Outputs
+# - 上位モジュールが依存に必要な最小限の値のみを出力します。
+###############################################
+
+output "detector_id" {
+  value       = aws_guardduty_detector.this.id
+  description = <<-EOT
+  作成された GuardDuty Detector の ID。
+  他モジュールで GuardDuty 関連設定を追加する際や、
+  コンソール/CLI での参照に利用できます。
+  EOT
+}
+

--- a/modules/security-guardduty/variables.tf
+++ b/modules/security-guardduty/variables.tf
@@ -1,0 +1,34 @@
+###############################################
+# Variables
+# すべての変数に詳細なコメントを付与します。
+###############################################
+
+variable "name_prefix" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  リソース名や Name タグに付与する任意のプレフィックス。
+  未指定（null/空文字）の場合は "guardduty" を使用します。
+  例: "security" を与えると "security-detector" のようなタグになります。
+  EOT
+}
+
+variable "auto_enable_members" {
+  type        = string
+  default     = "ALL"
+  description = <<-EOT
+  Organization 成員アカウントに対して GuardDuty を自動有効化する方法。
+  `ALL`  : 既存および新規すべてのメンバーに自動適用。
+  `NEW`  : 新規に参加したメンバーのみ自動適用。
+  `NONE` : 自動適用しない（上位から個別に有効化が必要）。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  共通タグ。最低限 Project/Env/Owner 等のタグ付与を推奨します。
+  EOT
+}
+


### PR DESCRIPTION
## Summary
- add `security-guardduty` module to enable GuardDuty detector and org-wide features
- document variables and outputs
- provide minimal example for module usage

## Testing
- `terraform fmt modules/security-guardduty/main.tf modules/security-guardduty/variables.tf modules/security-guardduty/outputs.tf examples/security-guardduty-minimal/main.tf`
- `terraform -chdir=examples/security-guardduty-minimal init -backend=false`
- `terraform -chdir=examples/security-guardduty-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0d452e694832ead9cb372ad021b9c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces a Terraform module to enable AWS GuardDuty for a single account or across an Organization with optional auto-enablement (ALL/NEW/NONE).
  * Activates key protections: S3 data events, EKS audit/runtime monitoring (with add-on management), Lambda network logs, RDS login events, and EBS malware protection.
  * Configurable via name prefix, tags, region, app name, and environment variables.
  * Outputs the created GuardDuty Detector ID for reuse.
  * Provides a minimal example to get started quickly.
  * Requires Terraform 1.9+ and a compatible AWS provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->