### PR TITLE
feat: add security hub module

### DIFF
--- a/examples/security-securityhub-minimal/main.tf
+++ b/examples/security-securityhub-minimal/main.tf
@@ -1,0 +1,75 @@
+###############################################
+# Example: security-securityhub (minimal)
+#
+# この例は、単一アカウントで Security Hub を有効化し、
+# Organization メンバーを自動有効化、AFSBP 標準に購読し、
+# Finding Aggregator で全リージョンのファインディングを集約する最小構成です。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+###############################################
+# Provider (repo-wide standard)
+###############################################
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Inputs for this example
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名。タグに使用します。"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "環境名（例: dev, stg, prd）。タグに使用します。"
+  default     = "dev"
+}
+
+###############################################
+# Step: Enable Security Hub
+###############################################
+module "securityhub" {
+  source = "../../modules/security-securityhub"
+
+  auto_enable_members = true
+  enable_afsbp        = true
+  linking_mode        = "ALL_REGIONS"
+}
+
+###############################################
+# Helpful outputs (for demo)
+###############################################
+output "finding_aggregator_arn" {
+  value       = module.securityhub.finding_aggregator_arn
+  description = "Security Hub Finding Aggregator の ARN"
+}
+

--- a/modules/security-securityhub/main.tf
+++ b/modules/security-securityhub/main.tf
@@ -1,0 +1,51 @@
+###############################################
+# Minimal Gov: Security Hub module
+#
+# このモジュールは AWS Security Hub を組織単位で有効化するための
+# 最小構成を提供します。主な機能:
+# - セキュリティアカウントで Security Hub を有効化
+# - Organization 成員アカウントを自動的に有効化
+# - AWS Foundational Security Best Practices への購読（任意）
+# - 全リージョンのファインディングを集約する Finding Aggregator の作成
+#
+# 設計指針:
+# - ロジックは単純明快に保ち、読みやすさを最優先
+# - セキュリティ既定値（組織への自動有効化等）はデフォルトで有効
+# - 出力は上位モジュールが依存する最小限（Aggregator ARN のみ）
+###############################################
+
+###############################################
+# Security Hub Account
+# - 現在のアカウントで Security Hub を有効化します。
+# - enable_* のフラグは存在しないため、リソースを作成するだけで有効化されます。
+###############################################
+resource "aws_securityhub_account" "this" {}
+
+###############################################
+# Organization Configuration
+# - auto_enable が true の場合、組織の新規/既存アカウントに
+#   Security Hub を自動的に有効化します。
+###############################################
+resource "aws_securityhub_organization_configuration" "this" {
+  auto_enable = var.auto_enable_members
+}
+
+###############################################
+# Standards Subscription (AFSBP)
+# - AWS Foundational Security Best Practices への購読を制御します。
+# - enable_afsbp が true の場合のみリソースを作成します。
+###############################################
+resource "aws_securityhub_standards_subscription" "afsbp" {
+  count         = var.enable_afsbp ? 1 : 0
+  standards_arn = "arn:aws:securityhub:::standards/aws-foundational-security-best-practices/v/1.0.0"
+}
+
+###############################################
+# Finding Aggregator
+# - 複数リージョンのファインディングを集約します。
+# - linking_mode を指定して集約方法を制御します。
+###############################################
+resource "aws_securityhub_finding_aggregator" "this" {
+  linking_mode = var.linking_mode
+}
+

--- a/modules/security-securityhub/outputs.tf
+++ b/modules/security-securityhub/outputs.tf
@@ -1,0 +1,13 @@
+###############################################
+# Outputs
+# - 上位モジュールが依存に必要な最小限の値のみを出力します。
+###############################################
+
+output "finding_aggregator_arn" {
+  value       = aws_securityhub_finding_aggregator.this.id
+  description = <<-EOT
+  作成された Security Hub Finding Aggregator の ARN。
+  他リージョンの集約設定や可視化ツールとの連携に利用できます。
+  EOT
+}
+

--- a/modules/security-securityhub/variables.tf
+++ b/modules/security-securityhub/variables.tf
@@ -1,0 +1,37 @@
+###############################################
+# Variables
+# すべての変数に詳細なコメントを付与します。
+###############################################
+
+variable "auto_enable_members" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  Organization 配下のアカウントに対して Security Hub を自動有効化するかどうか。
+  true  を指定すると、既存および新規に参加するすべてのメンバーアカウントで
+  Security Hub が自動的に有効になります。
+  false の場合は手動で各アカウントを有効化する必要があります。
+  EOT
+}
+
+variable "enable_afsbp" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  AWS Foundational Security Best Practices (AFSBP) 標準への購読を有効化するかどうか。
+  true  の場合、Security Hub の推奨ベースラインチェックを自動で適用します。
+  false の場合、標準購読は作成されません。
+  EOT
+}
+
+variable "linking_mode" {
+  type        = string
+  default     = "ALL_REGIONS"
+  description = <<-EOT
+  Finding Aggregator のリンク方法を指定します。
+  `ALL_REGIONS` を指定すると、全リージョンのファインディングを集約します。
+  特定リージョンのみを対象にする場合は `SPECIFIED_REGIONS` を指定し、
+  `regions` 引数を追加で設定します（本モジュールでは未サポート）。
+  EOT
+}
+


### PR DESCRIPTION
## Summary
- add Security Hub module with org auto-enable, optional AFSBP standard, and finding aggregator
- provide minimal example to use the module

## Testing
- `terraform fmt -recursive modules/security-securityhub examples/security-securityhub-minimal`
- `terraform -chdir=modules/security-securityhub init -backend=false`
- `terraform -chdir=modules/security-securityhub validate`
- `terraform -chdir=examples/security-securityhub-minimal init -backend=false`
- `terraform -chdir=examples/security-securityhub-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0db3270d0832eb6e90870d638873b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 単一アカウント向けの最小構成例を追加し、Security Hubの有効化、自動メンバー登録、AFSBP標準の有効化をサポート。
  - すべてのリージョンの検出結果を集約する設定に対応し、Finding Aggregator の ARN を出力。
  - モジュールで auto_enable_members / enable_afsbp / linking_mode を設定可能。
  - 入力変数（region, app_name, env）とプロバイダーのデフォルトタグ付与を追加。

- ドキュメント
  - モジュールと出力の日本語説明を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->