### PR TITLE
feat: SSO Permission Set モジュールの追加

### DIFF
--- a/examples/sso-permission-set-minimal/main.tf
+++ b/examples/sso-permission-set-minimal/main.tf
@@ -1,0 +1,78 @@
+###############################################
+# Example: sso-permission-set (minimal)
+#
+# この例では IAM Identity Center に AdministratorAccess 権限の
+# Permission Set を作成します。アカウントへの割当は行っていません。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Variables for example
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application タグに使用する名称"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment タグ用の値"
+  default     = "dev"
+}
+
+###############################################
+# Module invocation
+###############################################
+module "sso_permission_set" {
+  source = "../../modules/sso-permission-set"
+
+  permission_set_name = "AdministratorAccess"
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/AdministratorAccess"
+  ]
+
+  tags = {
+    Project = "minimal-gov"
+    Env     = var.env
+  }
+}
+
+###############################################
+# Outputs
+###############################################
+output "permission_set_arn" {
+  description = "作成された Permission Set の ARN"
+  value       = module.sso_permission_set.permission_set_arn
+}
+

--- a/modules/sso-permission-set/main.tf
+++ b/modules/sso-permission-set/main.tf
@@ -1,0 +1,72 @@
+###############################################
+# Minimal Gov: SSO Permission Set module
+#
+# この module は AWS IAM Identity Center (旧 AWS SSO) に
+# Permission Set を作成し、指定された AWS マネージドポリシーを
+# アタッチします。また、必要に応じて複数アカウント・ユーザ/グループ
+# へ割り当てを行います。
+#
+# 主なリソース:
+# - aws_ssoadmin_permission_set: Permission Set 本体
+# - aws_ssoadmin_managed_policy_attachment: マネージドポリシーの付与
+# - aws_ssoadmin_account_assignment: アカウントへの割当
+#
+# 設計方針:
+# - ロジックは可能な限り単純に保ち、コメントで詳細を説明
+# - 変数化を徹底し、読みやすさを最優先
+# - 安全な既定値 (セッション有効期限 8 時間 など) を採用
+# - 上位 module に不要な情報は出力しない
+###############################################
+
+# SSO インスタンス ARN を決定する。
+# 入力が無ければ最初のインスタンスを自動検出する。
+data "aws_ssoadmin_instances" "this" {}
+
+locals {
+  instance_arn = var.instance_arn != null && var.instance_arn != "" ? var.instance_arn : data.aws_ssoadmin_instances.this.arns[0]
+}
+
+###############################################
+# Permission Set 本体
+###############################################
+resource "aws_ssoadmin_permission_set" "this" {
+  name         = var.permission_set_name
+  instance_arn = local.instance_arn
+
+  # セッション継続時間を指定 (既定 8 時間)。
+  session_duration = var.session_duration
+
+  # 任意のタグを付与。上位で default_tags を設定していない場合にもタグ付け可能。
+  tags = var.tags
+}
+
+###############################################
+# マネージドポリシーの付与
+###############################################
+# 指定された各 AWS マネージドポリシーを Permission Set にアタッチする。
+resource "aws_ssoadmin_managed_policy_attachment" "this" {
+  for_each           = toset(var.managed_policy_arns)
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this.arn
+  managed_policy_arn = each.value
+}
+
+###############################################
+# Permission Set のアカウント割当
+###############################################
+# 複数のアカウント / ユーザまたはグループへの割当を定義する。
+# assignments 変数が空の場合、このリソースは作成されない。
+resource "aws_ssoadmin_account_assignment" "this" {
+  for_each = {
+    for assignment in var.assignments :
+    "${assignment.account_id}-${assignment.principal_type}-${assignment.principal_id}" => assignment
+  }
+
+  instance_arn       = local.instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this.arn
+  principal_id       = each.value.principal_id
+  principal_type     = each.value.principal_type
+  target_id          = each.value.account_id
+  target_type        = "AWS_ACCOUNT"
+}
+

--- a/modules/sso-permission-set/outputs.tf
+++ b/modules/sso-permission-set/outputs.tf
@@ -1,0 +1,10 @@
+###############################################
+# Outputs
+# 上位 module が依存関係として利用する最小限の値のみを公開します。
+###############################################
+
+output "permission_set_arn" {
+  description = "作成された Permission Set の ARN。追加の割当や監査で参照します。"
+  value       = aws_ssoadmin_permission_set.this.arn
+}
+

--- a/modules/sso-permission-set/variables.tf
+++ b/modules/sso-permission-set/variables.tf
@@ -1,0 +1,68 @@
+###############################################
+# Variables
+# すべての入力変数には詳細な説明を付与しています。
+###############################################
+
+variable "permission_set_name" {
+  type        = string
+  description = <<-EOT
+  IAM Identity Center で作成する Permission Set の名称。
+  例: "AdministratorAccess" や "ReadOnly" など、利用目的がわかる名前を指定します。
+  EOT
+}
+
+variable "managed_policy_arns" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+  Permission Set にアタッチする AWS マネージドポリシーの ARN 一覧。
+  例: "arn:aws:iam::aws:policy/AdministratorAccess"。
+  空リストの場合、ポリシーは付与されません。
+  EOT
+}
+
+variable "instance_arn" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  対象となる IAM Identity Center インスタンスの ARN。
+  通常は自動検出で十分なため、省略可能です。
+  複数インスタンスが存在する場合に特定したいときのみ指定します。
+  EOT
+}
+
+variable "assignments" {
+  type = list(object({
+    account_id     = string
+    principal_type = string
+    principal_id   = string
+  }))
+  default     = []
+  description = <<-EOT
+  Permission Set を割り当てるアカウントとユーザ/グループの一覧。
+  `account_id` は 12 桁の AWS アカウント ID、
+  `principal_type` は "USER" または "GROUP" を指定します。
+  `principal_id` は IAM Identity Center のユーザ/グループ ID です。
+  空リストの場合、割当は作成されません。
+  EOT
+}
+
+variable "session_duration" {
+  type        = string
+  default     = "PT8H"
+  description = <<-EOT
+  Permission Set によるセッションの最大継続時間。
+  ISO 8601 形式で指定し、既定は 8 時間 (PT8H) です。
+  業務要件に合わせて変更してください。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  Permission Set に付与する任意のタグのマップ。
+  組織のタグ基準に従い、必要なキー/値を指定してください。
+  EOT
+}
+


### PR DESCRIPTION
## 概要
- IAM Identity Center 用の Permission Set モジュールを追加
- マネージドポリシー付与とアカウント割当をサポート
- 最小構成の使用例を追加

## テスト
- `terraform fmt modules/sso-permission-set/main.tf modules/sso-permission-set/variables.tf modules/sso-permission-set/outputs.tf examples/sso-permission-set-minimal/main.tf`
- `terraform -chdir=examples/sso-permission-set-minimal init -backend=false`
- `terraform -chdir=examples/sso-permission-set-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0e14be804832e954b82183d5f1a46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - IAM Identity CenterのPermission Setを作成・管理するTerraformモジュールを追加
  - 管理ポリシーの複数添付、アカウント割り当て、セッション有効期限設定、タグ付けに対応
  - インスタンスARNの自動検出をサポート（明示指定も可能）
  - 作成したPermission SetのARNを出力
- ドキュメント
  - 最小構成のサンプルを追加（AdministratorAccessを用いたPermission Set作成例、出力例付き。割り当ては含まれません）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->