### PR TITLE
feat: add vpn tgw module

### DIFF
--- a/examples/vpn-tgw-minimal/main.tf
+++ b/examples/vpn-tgw-minimal/main.tf
@@ -1,0 +1,72 @@
+###############################################
+# Example: vpn-tgw (minimal)
+#
+# この例は、本モジュールを最小限の入力で実行できる構成です。
+# - 簡易的な Transit Gateway を作成
+# - Customer Gateway + VPN 接続を作成し、2 つの静的ルートを追加
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+###############################################
+# Transit Gateway (example purposes)
+# 実際の環境では既存の TGW ID を渡すことを想定しています。
+###############################################
+resource "aws_ec2_transit_gateway" "this" {
+  description     = "example tgw"
+  amazon_side_asn = 64512
+}
+
+module "vpn_tgw" {
+  source = "../../modules/vpn-tgw"
+
+  env                      = "dev"
+  app_name                 = "minimal-gov"
+  region                   = var.region
+  name_prefix              = "user"
+  customer_gateway_ip      = "203.0.113.1"
+  customer_gateway_bgp_asn = 65000
+  transit_gateway_id       = aws_ec2_transit_gateway.this.id
+  vpn_static_routes        = ["10.0.0.0/16", "10.2.0.0/16"]
+  tags = {
+    Project = "minimal-gov"
+    Env     = "dev"
+  }
+}
+
+output "customer_gateway_id" {
+  value       = module.vpn_tgw.customer_gateway_id
+  description = "作成された Customer Gateway ID"
+}
+
+output "vpn_connection_id" {
+  value       = module.vpn_tgw.vpn_connection_id
+  description = "作成された VPN 接続 ID"
+}
+
+output "tunnel_endpoints" {
+  description = "AWS 側トンネル IP アドレス"
+  value = {
+    tunnel1 = module.vpn_tgw.tunnel1_address
+    tunnel2 = module.vpn_tgw.tunnel2_address
+  }
+}
+

--- a/modules/vpn-tgw/main.tf
+++ b/modules/vpn-tgw/main.tf
@@ -1,0 +1,97 @@
+###############################################
+# Minimal Gov: vpn-tgw module
+#
+# このモジュールは以下のリソースを作成します:
+# - Customer Gateway (オンプレミス側の VPN デバイス情報)
+# - Transit Gateway への Site-to-Site VPN 接続
+# - 静的ルート (必要な宛先 CIDR のみ)
+#
+# すべてのリソースはセキュアな既定値で作成され、IKEv2 のみを許可します。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Locals
+# - name_prefix: リソース名/タグに利用するプレフィックス。
+#                未指定の場合は "vpn" を使用します。
+###############################################
+locals {
+  name_prefix = var.name_prefix != null && var.name_prefix != "" ? var.name_prefix : "vpn"
+}
+
+###############################################
+# Customer Gateway
+# - オンプレミス側の VPN デバイス（パブリック IP）を AWS に登録します。
+# - BGP ASN は静的ルーティングでも必須値のため入力を求めます。
+###############################################
+resource "aws_customer_gateway" "this" {
+  bgp_asn    = var.customer_gateway_bgp_asn
+  ip_address = var.customer_gateway_ip
+  type       = "ipsec.1"
+
+  tags = merge(
+    {
+      Name = "${local.name_prefix}-cgw"
+    },
+    var.tags,
+  )
+}
+
+###############################################
+# VPN Connection (to Transit Gateway)
+# - 静的ルートのみを許可し、BGP を利用しません。
+# - IKEv2 を強制し、暗号化アルゴリズムは AWS 既定値を使用します。
+###############################################
+resource "aws_vpn_connection" "this" {
+  customer_gateway_id = aws_customer_gateway.this.id
+  transit_gateway_id  = var.transit_gateway_id
+  type                = "ipsec.1"
+
+  static_routes_only = true
+
+  # IKEv2 のみを許可（セキュアな既定値）
+  tunnel1_ike_versions = ["ikev2"]
+  tunnel2_ike_versions = ["ikev2"]
+
+  tags = merge(
+    {
+      Name = "${local.name_prefix}-vpn"
+    },
+    var.tags,
+  )
+}
+
+###############################################
+# VPN Connection Routes
+# - 接続先 CIDR ごとに静的ルートを作成します。
+###############################################
+resource "aws_vpn_connection_route" "this" {
+  for_each = { for cidr in var.vpn_static_routes : cidr => cidr }
+
+  vpn_connection_id      = aws_vpn_connection.this.id
+  destination_cidr_block = each.value
+}
+

--- a/modules/vpn-tgw/outputs.tf
+++ b/modules/vpn-tgw/outputs.tf
@@ -1,0 +1,26 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみ出力します。
+# 利用方法のヒントをコメントとして併記します。
+###############################################
+
+output "customer_gateway_id" {
+  description = "作成された Customer Gateway の ID。例: CloudWatch ログや別 VPN 設定の参照に利用。"
+  value       = aws_customer_gateway.this.id
+}
+
+output "vpn_connection_id" {
+  description = "作成された Site-to-Site VPN 接続 ID。例: VPN ログの有効化やルートテーブル関連付けに利用。"
+  value       = aws_vpn_connection.this.id
+}
+
+output "tunnel1_address" {
+  description = "AWS 側トンネル 1 のエンドポイント IP。オンプレデバイス設定時に利用します。"
+  value       = aws_vpn_connection.this.tunnel1_address
+}
+
+output "tunnel2_address" {
+  description = "AWS 側トンネル 2 のエンドポイント IP。オンプレデバイス設定時に利用します。"
+  value       = aws_vpn_connection.this.tunnel2_address
+}
+

--- a/modules/vpn-tgw/variables.tf
+++ b/modules/vpn-tgw/variables.tf
@@ -1,0 +1,86 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "env" {
+  type        = string
+  description = "デプロイ対象の環境名 (例: dev, prod)。タグ付与およびリソース名に利用します。"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名。provider の default_tags に設定されます。"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS リージョン。provider 設定およびタグに利用します。"
+}
+
+variable "name_prefix" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  リソースの論理名や Name タグに付与するプレフィックス。
+  未指定（null/空文字）の場合は "vpn" を用います。
+  EOT
+}
+
+variable "customer_gateway_ip" {
+  type        = string
+  description = <<-EOT
+  オンプレミス側 VPN デバイスのパブリック IP アドレス。
+  例: "203.0.113.1"。
+  EOT
+
+  validation {
+    # cidrhost を用いることで IPv4 形式か簡易チェック
+    condition     = can(cidrhost("${var.customer_gateway_ip}/32", 0))
+    error_message = "customer_gateway_ip は有効な IPv4 形式で指定してください。"
+  }
+}
+
+variable "customer_gateway_bgp_asn" {
+  type        = number
+  description = <<-EOT
+  オンプレミス側の BGP ASN。静的ルーティングのみを利用する場合でも必須です。
+  一般的には 64512-65534 のプライベート ASN を指定します。
+  EOT
+
+  validation {
+    condition     = var.customer_gateway_bgp_asn > 0 && var.customer_gateway_bgp_asn < 4294967295
+    error_message = "customer_gateway_bgp_asn は 1 以上 4294967294 以下の数値で指定してください。"
+  }
+}
+
+variable "transit_gateway_id" {
+  type        = string
+  description = "接続先となる Transit Gateway の ID (例: tgw-xxxxxxxxxxxxxxxxx)。"
+
+  validation {
+    condition     = length(var.transit_gateway_id) > 4 && substr(var.transit_gateway_id, 0, 4) == "tgw-"
+    error_message = "transit_gateway_id は 'tgw-' で始まる有効な ID を指定してください。"
+  }
+}
+
+variable "vpn_static_routes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+  VPN 接続に追加する静的ルートの CIDR ブロック一覧。
+  例: ["10.0.0.0/16", "10.2.0.0/16"]
+  EOT
+
+  validation {
+    condition     = alltrue([for cidr in var.vpn_static_routes : can(cidrnetmask(cidr))])
+    error_message = "vpn_static_routes の各要素は有効な CIDR 形式で指定してください。"
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "追加で付与する任意のタグ。provider の default_tags とマージされます。"
+}
+


### PR DESCRIPTION
## Summary
- VPN と TGW を接続する `vpn-tgw` モジュールを追加
- 最小構成の利用例 `examples/vpn-tgw-minimal` を追加

## Testing
- `terraform fmt -recursive`
- `cd examples/vpn-tgw-minimal && terraform init -backend=false`
- `cd examples/vpn-tgw-minimal && terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0e1770910832e8625421e18414bd6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 新機能
  * 最小構成の AWS VPN Transit Gateway セットアップ例を追加。
  * 再利用可能なモジュールで Customer Gateway・VPN 接続・静的ルートを自動作成。
  * 出力として Customer Gateway ID、VPN 接続 ID、トンネル IP（tunnel1/2）を公開。
  * 入力値のバリデーションを追加（IPv4、BGP ASN、CIDR、TGW ID）。
  * IKEv2 のみ対応、静的ルーティング前提の構成。
  * リージョン変数（既定 ap-northeast-1）とタグ統合に対応。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->