### PR TITLE
feat: VPN VGW モジュールの追加

### DIFF
--- a/examples/vpn-vgw-minimal/main.tf
+++ b/examples/vpn-vgw-minimal/main.tf
@@ -1,0 +1,108 @@
+###############################################
+# Example: vpn-vgw (minimal)
+#
+# この例は、vpn-vgw モジュールを用いて VGW + VPN を最小限の
+# 入力で構築する方法を示します。
+# - デモ用に 1 つのプライベートサブネットのみを持つ VPC を作成
+# - オンプレ側 IP はダミー (203.0.113.1) を使用
+# - 静的ルートとして 10.1.0.0/16 を登録
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  # レポジトリ共通のタグ付与（設計書準拠）
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Variables (example locals)
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名（タグ用）"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "環境名（タグ用）"
+  default     = "dev"
+}
+
+###############################################
+# VPC（最小構成）
+###############################################
+module "vpc_spoke" {
+  source = "../../modules/vpc-spoke"
+
+  name_prefix                 = "vpn"
+  vpc_cidr                    = "10.100.0.0/16"
+  azs                         = ["${var.region}a"]
+  private_subnet_count_per_az = 1
+  subnet_newbits              = 8
+
+  tags = {
+    Project = var.app_name
+    Env     = var.env
+  }
+}
+
+###############################################
+# VGW + VPN Connection
+###############################################
+module "vpn_vgw" {
+  source = "../../modules/vpn-vgw"
+
+  vpc_id                   = module.vpc_spoke.vpc_id
+  customer_gateway_ip      = "203.0.113.1" # 例: オンプレ側のグローバル IP
+  customer_gateway_bgp_asn = 65000
+  routes                   = ["10.1.0.0/16"]
+  amazon_side_asn          = 64512
+  vgw_name                 = "net-vgw"
+  cgw_name                 = "onprem-cgw"
+  vpn_connection_name      = "net-vpn"
+
+  tags = {
+    Project = var.app_name
+    Env     = var.env
+  }
+}
+
+###############################################
+# Outputs (example)
+###############################################
+output "vgw_id" {
+  description = "作成された VGW ID"
+  value       = module.vpn_vgw.vgw_id
+}
+
+output "vpn_connection_id" {
+  description = "作成された VPN 接続 ID"
+  value       = module.vpn_vgw.vpn_connection_id
+}
+

--- a/modules/vpn-vgw/main.tf
+++ b/modules/vpn-vgw/main.tf
@@ -1,0 +1,87 @@
+###############################################
+# Minimal Gov: VPN via VGW module
+#
+# このモジュールは以下のリソースを作成します:
+# - Virtual Private Gateway (VGW)
+# - VGW を指定された VPC にアタッチ
+# - Customer Gateway (オンプレ側)
+# - VPN Connection (VGW ↔ Customer Gateway)
+# - オンプレ宛の静的ルート
+#
+# これにより Network アカウントとオンプレ/DC 間の Site-to-Site VPN を
+# 迅速かつ安全に構築できます。VPN は静的ルートのみを許可し、
+# セキュアなデフォルトで構成されています。
+###############################################
+
+###############################################
+# VGW 本体
+# - Amazon 側 ASN は既定 64512（必要に応じて変更可能）
+###############################################
+resource "aws_vpn_gateway" "this" {
+  amazon_side_asn = var.amazon_side_asn
+
+  tags = merge(
+    {
+      Name = var.vgw_name
+    },
+    var.tags,
+  )
+}
+
+###############################################
+# VGW ↔ VPC の関連付け
+# - 指定された VPC に VGW をアタッチします。
+###############################################
+resource "aws_vpn_gateway_attachment" "this" {
+  vpn_gateway_id = aws_vpn_gateway.this.id
+  vpc_id         = var.vpc_id
+}
+
+###############################################
+# Customer Gateway（オンプレ側）
+# - オンプレ拠点のグローバル IP と BGP ASN を登録
+###############################################
+resource "aws_customer_gateway" "this" {
+  bgp_asn    = var.customer_gateway_bgp_asn
+  ip_address = var.customer_gateway_ip
+  type       = "ipsec.1"
+
+  tags = merge(
+    {
+      Name = var.cgw_name
+    },
+    var.tags,
+  )
+}
+
+###############################################
+# VPN Connection（VGW ↔ Customer Gateway）
+# - 静的ルートのみを許可しシンプルに構成
+###############################################
+resource "aws_vpn_connection" "this" {
+  vpn_gateway_id      = aws_vpn_gateway.this.id
+  customer_gateway_id = aws_customer_gateway.this.id
+  type                = "ipsec.1"
+
+  # BGP を使わず静的ルートで運用するため true
+  static_routes_only = true
+
+  tags = merge(
+    {
+      Name = var.vpn_connection_name
+    },
+    var.tags,
+  )
+}
+
+###############################################
+# VPN 接続の静的ルート
+# - オンプレミス側の宛先 CIDR を登録
+###############################################
+resource "aws_vpn_connection_route" "this" {
+  for_each = toset(var.routes)
+
+  vpn_connection_id      = aws_vpn_connection.this.id
+  destination_cidr_block = each.key
+}
+

--- a/modules/vpn-vgw/outputs.tf
+++ b/modules/vpn-vgw/outputs.tf
@@ -1,0 +1,18 @@
+###############################################
+# Outputs from vpn-vgw module
+###############################################
+
+# 作成された VGW の ID
+# - ルートテーブルへの伝播設定など、上位モジュールでの参照に利用
+output "vgw_id" {
+  description = "作成された VGW の ID"
+  value       = aws_vpn_gateway.this.id
+}
+
+# 作成された VPN Connection の ID
+# - 監視設定や追加ルート登録時に参照
+output "vpn_connection_id" {
+  description = "作成された VPN 接続 ID"
+  value       = aws_vpn_connection.this.id
+}
+

--- a/modules/vpn-vgw/variables.tf
+++ b/modules/vpn-vgw/variables.tf
@@ -1,0 +1,68 @@
+###############################################
+# Variables for vpn-vgw module
+###############################################
+
+# VGW をアタッチする対象 VPC の ID
+variable "vpc_id" {
+  type        = string
+  description = "VGW をアタッチする VPC の ID"
+}
+
+# オンプレ側のグローバル IP アドレス
+# - Customer Gateway の IP として登録されます
+variable "customer_gateway_ip" {
+  type        = string
+  description = "オンプレミス側ゲートウェイのグローバル IP アドレス"
+}
+
+# オンプレ側の BGP ASN
+# - Customer Gateway の BGP ASN として使用
+variable "customer_gateway_bgp_asn" {
+  type        = number
+  description = "オンプレミス側ゲートウェイの BGP ASN"
+}
+
+# VGW 側の Amazon ASN
+# - 既定 64512。必要に応じて変更
+variable "amazon_side_asn" {
+  type        = number
+  description = "VGW に割り当てる Amazon 側 ASN"
+  default     = 64512
+}
+
+# オンプレ側ネットワークへの静的ルート一覧
+# - 例: ["10.0.0.0/16", "10.1.0.0/16"]
+variable "routes" {
+  type        = list(string)
+  description = "オンプレミス側宛の CIDR 一覧（静的ルート用）"
+  default     = []
+}
+
+# VGW の Name タグ
+variable "vgw_name" {
+  type        = string
+  description = "VGW に付与する Name タグ"
+  default     = "vgw"
+}
+
+# Customer Gateway の Name タグ
+variable "cgw_name" {
+  type        = string
+  description = "Customer Gateway に付与する Name タグ"
+  default     = "cgw"
+}
+
+# VPN Connection の Name タグ
+variable "vpn_connection_name" {
+  type        = string
+  description = "VPN Connection に付与する Name タグ"
+  default     = "vpn-connection"
+}
+
+# 追加で付与する共通タグ
+variable "tags" {
+  type        = map(string)
+  description = "リソースへ付与する追加タグ"
+  default     = {}
+}
+


### PR DESCRIPTION
## 概要
- VGW と VPN 接続をまとめて構築する `vpn-vgw` モジュールを追加
- 最小構成の利用例 `examples/vpn-vgw-minimal` を追加

## テスト
- `terraform fmt modules/vpn-vgw/main.tf modules/vpn-vgw/variables.tf modules/vpn-vgw/outputs.tf examples/vpn-vgw-minimal/main.tf`
- `terraform -chdir=modules/vpn-vgw init -backend=false`
- `terraform -chdir=modules/vpn-vgw validate`
- `terraform -chdir=examples/vpn-vgw-minimal init -backend=false`
- `terraform -chdir=examples/vpn-vgw-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0e1b22f98832e8d5a3ea30f8d5796