### PR TITLE
feat: Bastion モジュール追加

### DIFF
--- a/examples/bastion-minimal/main.tf
+++ b/examples/bastion-minimal/main.tf
@@ -1,0 +1,99 @@
+###############################################
+# Example: bastion (minimal)
+#
+# この例は、本モジュールを最小限の構成で利用する方法を示します。
+# - 単純な VPC + プライベートサブネット + SG を作成
+# - そのサブネット上に SSM で接続可能な踏み台 EC2 を 1 台起動
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+variable "region" {
+  description = "デプロイ先リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  description = "アプリケーション名（タグ用）"
+  type        = string
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  description = "環境名（タグ用）"
+  type        = string
+  default     = "dev"
+}
+
+###############################################
+# 最小限の VPC / Subnet / SG
+###############################################
+resource "aws_vpc" "this" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "private" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = "10.0.0.0/24"
+  map_public_ip_on_launch = false
+}
+
+resource "aws_security_group" "bastion" {
+  name   = "bastion-sg"
+  vpc_id = aws_vpc.this.id
+
+  # ここではアウトバウンドのみ許可（インバウンドは SSM セッション経由）
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+###############################################
+# Bastion Module
+###############################################
+module "bastion" {
+  source = "../../modules/bastion"
+
+  subnet_id         = aws_subnet.private.id
+  security_group_id = aws_security_group.bastion.id
+  instance_type     = "t3.micro"
+
+  tags = {
+    Project = "minimal-gov"
+    Env     = "dev"
+  }
+}
+
+output "bastion_instance_id" {
+  value       = module.bastion.instance_id
+  description = "作成された Bastion EC2 の ID"
+}
+

--- a/modules/bastion/main.tf
+++ b/modules/bastion/main.tf
@@ -1,0 +1,116 @@
+###############################################
+# Minimal Gov: Bastion module
+#
+# このモジュールは、プライベートサブネット内に SSM/EIC 接続が可能な
+# 踏み台用 EC2 インスタンスを 1 台作成します。
+# - Amazon Linux 2023 を既定 AMI として自動取得（指定も可能）
+# - SSM 管理用 IAM ロール + 任意の追加ポリシーアタッチ
+# - ルートボリュームの暗号化、IMDSv2 強制などのセキュリティ既定値
+#
+# 入力はシンプルさを優先し、既存のサブネット/セキュリティグループ
+# を指定するだけで利用できます。
+###############################################
+
+###############################################
+# Locals
+###############################################
+locals {
+  # name_prefix は未指定なら "bastion" を利用
+  name_prefix = var.name_prefix != null && var.name_prefix != "" ? var.name_prefix : "bastion"
+
+  # 使用する AMI ID。指定がない場合は Amazon Linux 2023 の最新を自動取得
+  ami_id = var.ami_id != null && var.ami_id != "" ? var.ami_id : data.aws_ami.al2023[0].id
+
+  # IAM ポリシー。SSM 管理ポリシーを既定で付与し、追加分を連結
+  iam_policy_arns = concat([
+    "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
+  ], var.iam_policy_arns)
+}
+
+###############################################
+# Data Sources
+# - Amazon Linux 2023 の最新 AMI を検索（必要時のみ）
+###############################################
+data "aws_ami" "al2023" {
+  count       = var.ami_id == null || var.ami_id == "" ? 1 : 0
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+###############################################
+# IAM Role & Instance Profile
+# - EC2 から SSM や追加ポリシーを利用するためのロール
+###############################################
+resource "aws_iam_role" "this" {
+  name = "${local.name_prefix}-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = merge({
+    Name = "${local.name_prefix}-role"
+  }, var.tags)
+}
+
+resource "aws_iam_instance_profile" "this" {
+  name = "${local.name_prefix}-profile"
+  role = aws_iam_role.this.name
+}
+
+# 指定された各ポリシーをロールへアタッチ
+resource "aws_iam_role_policy_attachment" "this" {
+  for_each   = toset(local.iam_policy_arns)
+  role       = aws_iam_role.this.name
+  policy_arn = each.value
+}
+
+###############################################
+# EC2 Instance (Bastion)
+# - プライベートサブネットに配置、SSM 経由で操作
+# - ルートボリューム暗号化、IMDSv2 強制などを有効化
+###############################################
+resource "aws_instance" "this" {
+  ami                    = local.ami_id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.security_group_id]
+  iam_instance_profile   = aws_iam_instance_profile.this.name
+
+  # パブリック IP は割り当てず、踏み台としての閉域性を維持
+  associate_public_ip_address = false
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required" # IMDSv2 を強制
+  }
+
+  # ルートボリュームは既定 KMS で暗号化
+  root_block_device {
+    encrypted = true
+  }
+
+  tags = merge({
+    Name = "${local.name_prefix}-ec2"
+  }, var.tags)
+}
+

--- a/modules/bastion/outputs.tf
+++ b/modules/bastion/outputs.tf
@@ -1,0 +1,10 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみ出力します。
+###############################################
+
+output "instance_id" {
+  description = "作成された Bastion EC2 の ID。例: SSM セッションのターゲットに module.bastion.instance_id を渡す。"
+  value       = aws_instance.this.id
+}
+

--- a/modules/bastion/variables.tf
+++ b/modules/bastion/variables.tf
@@ -1,0 +1,68 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "name_prefix" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  リソース名や Name タグに付与する任意のプレフィックス。
+  未指定（null/空文字）の場合は "bastion" を使用します。
+  EOT
+}
+
+variable "subnet_id" {
+  type        = string
+  description = <<-EOT
+  踏み台 EC2 を配置するサブネット ID。
+  原則としてプライベートサブネットを指定してください。
+  EOT
+}
+
+variable "security_group_id" {
+  type        = string
+  description = <<-EOT
+  EC2 インスタンスに適用する既存セキュリティグループの ID。
+  SSH/SSM/EIC への必要な許可を事前に設定してください。
+  EOT
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.micro"
+  description = <<-EOT
+  起動する EC2 のインスタンスタイプ。
+  小規模用途では t3.micro などのバースト系がコスト効率に優れます。
+  EOT
+}
+
+variable "ami_id" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  使用する AMI の ID。
+  未指定時は Amazon Linux 2023 の最新 AMI を自動検索して利用します。
+  特定バージョンを固定したい場合に指定してください。
+  EOT
+}
+
+variable "iam_policy_arns" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+  EC2 用 IAM ロールに追加でアタッチするポリシー ARN のリスト。
+  既定で AmazonSSMManagedInstanceCore は自動付与されるため、
+  S3 アクセスなど追加権限が必要な場合のみ指定してください。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  すべてのリソースに付与する共通タグ。
+  例: { Project = "minimal-gov", Env = "dev" }
+  EOT
+}
+


### PR DESCRIPTION
## 概要
- Bastion 用 Terraform モジュールを追加
- 最小構成で利用できるサンプルを追加

## テスト
- `terraform fmt modules/bastion/main.tf modules/bastion/variables.tf modules/bastion/outputs.tf examples/bastion-minimal/main.tf`
- `cd examples/bastion-minimal && terraform init -backend=false`
- `cd examples/bastion-minimal && terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0e1f03a8c832e8a94b1729722cf9e