### PR TITLE
feat: add onprem simulation module

### DIFF
--- a/examples/onprem-sim-minimal/main.tf
+++ b/examples/onprem-sim-minimal/main.tf
@@ -1,0 +1,91 @@
+###############################################
+# Example: onprem-sim (minimal)
+#
+# この例は onprem-sim モジュールを用いて、最小限の疑似オンプレ環境
+# (VPC + strongSwan EC2 + EIP) を構築する方法を示します。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Variables for example
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application タグに使用する名称"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment タグ用の値"
+  default     = "dev"
+}
+
+###############################################
+# Module invocation
+###############################################
+module "onprem_sim" {
+  source = "../../modules/onprem-sim"
+
+  vpc_cidr           = "10.255.0.0/16"
+  public_subnet_cidr = "10.255.0.0/24"
+  az                 = "${var.region}a"
+  instance_type      = "t3.small"
+  tags = {
+    Project = "minimal-gov"
+    Env     = var.env
+  }
+}
+
+###############################################
+# Outputs
+###############################################
+output "vpc_id" {
+  description = "作成された疑似オンプレ VPC の ID"
+  value       = module.onprem_sim.vpc_id
+}
+
+output "subnet_id" {
+  description = "パブリックサブネットの ID"
+  value       = module.onprem_sim.subnet_id
+}
+
+output "instance_id" {
+  description = "strongSwan EC2 インスタンスの ID"
+  value       = module.onprem_sim.instance_id
+}
+
+output "eip" {
+  description = "強制割り当てられた Elastic IP アドレス"
+  value       = module.onprem_sim.eip
+}
+

--- a/modules/onprem-sim/main.tf
+++ b/modules/onprem-sim/main.tf
@@ -1,0 +1,178 @@
+###############################################
+# Minimal Gov: On-prem Simulation module
+#
+# このモジュールはデモ用の「擬似オンプレ環境」を AWS 上に構築します。
+# 以下のリソースをまとめて作成し、Site-to-Site VPN の動作確認などに
+# 利用できる最小構成を提供します。
+#
+# 作成する主なリソース:
+# - VPC（指定した CIDR で作成）
+# - パブリックサブネット + ルートテーブル + IGW（インターネット接続）
+# - strongSwan EC2 インスタンス（EIP 付与、Src/Dst チェック無効）
+#
+# 設計指針:
+# - ロジックは可能な限り単純化し、読みやすさを最優先
+# - セキュリティ既定値を有効化（暗号化、公開ブロック等）
+# - 上位モジュールが依存する最小限の値のみを出力
+###############################################
+
+###############################################
+# Data sources
+# - AMI: 既定では Amazon Linux 2023 を使用。
+#   strongSwan 専用 AMI を利用する場合は ami_id 変数で上書きします。
+###############################################
+
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-kernel-6.1-x86_64*"]
+  }
+}
+
+locals {
+  # AMI ID は入力で指定された場合を優先し、未指定なら上記データソースを使用
+  ami_id = var.ami_id != null && var.ami_id != "" ? var.ami_id : data.aws_ami.al2023.id
+}
+
+###############################################
+# VPC and networking components
+###############################################
+
+# ベースとなる VPC
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge({
+    Name = "${var.name_prefix}-vpc"
+  }, var.tags)
+}
+
+# インターネットゲートウェイ（外部との通信を可能にする）
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge({
+    Name = "${var.name_prefix}-igw"
+  }, var.tags)
+}
+
+# パブリックサブネット（strongSwan を配置）
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = var.az
+  map_public_ip_on_launch = false # EIP を使用するため自動割当は無効化
+
+  tags = merge({
+    Name = "${var.name_prefix}-public"
+  }, var.tags)
+}
+
+# ルートテーブル（IGW へ 0.0.0.0/0 をルーティング）
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge({
+    Name = "${var.name_prefix}-public-rt"
+  }, var.tags)
+}
+
+# インターネット向けデフォルトルート
+resource "aws_route" "public_inet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+# サブネットとルートテーブルの関連付け
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+###############################################
+# Security group for strongSwan instance
+###############################################
+resource "aws_security_group" "cgw" {
+  name        = "${var.name_prefix}-cgw-sg"
+  description = "Allow IPsec (UDP 500/4500) and ICMP for diagnostics"
+  vpc_id      = aws_vpc.this.id
+
+  # IKE (UDP 500)
+  ingress {
+    from_port   = 500
+    to_port     = 500
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow IKEv2"
+  }
+
+  # NAT-T (UDP 4500)
+  ingress {
+    from_port   = 4500
+    to_port     = 4500
+    protocol    = "udp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow NAT-T"
+  }
+
+  # ICMP for connectivity checks
+  ingress {
+    from_port   = -1
+    to_port     = -1
+    protocol    = "icmp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow ICMP"
+  }
+
+  # Outbound: すべて許可（VPN トラフィックのため）
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge({
+    Name = "${var.name_prefix}-cgw-sg"
+  }, var.tags)
+}
+
+###############################################
+# EC2 instance representing on-premises gateway
+###############################################
+resource "aws_instance" "cgw" {
+  ami                         = local.ami_id
+  instance_type               = var.instance_type
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.cgw.id]
+  associate_public_ip_address = false
+  source_dest_check           = false # VPN ルータとして動作させるため
+
+  root_block_device {
+    encrypted = true # デフォルトで EBS を暗号化
+  }
+
+  tags = merge({
+    Name = "${var.name_prefix}-cgw"
+  }, var.tags)
+}
+
+# Elastic IP を割り当て、外部から固定 IP でアクセス可能にする
+resource "aws_eip" "cgw" {
+  domain   = "vpc" # VPC 用 EIP を明示
+  instance = aws_instance.cgw.id
+
+  tags = merge({
+    Name = "${var.name_prefix}-eip"
+  }, var.tags)
+}
+
+###############################################
+# Outputs are defined in outputs.tf
+###############################################

--- a/modules/onprem-sim/outputs.tf
+++ b/modules/onprem-sim/outputs.tf
@@ -1,0 +1,25 @@
+###############################################
+# Outputs
+# 利用者が上位モジュールから参照する必要がある最小限の値のみを公開します。
+###############################################
+
+output "vpc_id" {
+  description = "作成された疑似オンプレ VPC の ID。VPN 接続設定などで参照します。"
+  value       = aws_vpc.this.id
+}
+
+output "subnet_id" {
+  description = "strongSwan インスタンスが存在するパブリックサブネットの ID。追加リソース配置時に使用します。"
+  value       = aws_subnet.public.id
+}
+
+output "instance_id" {
+  description = "strongSwan EC2 インスタンスの ID。SSM 接続や監視設定で参照可能です。"
+  value       = aws_instance.cgw.id
+}
+
+output "eip" {
+  description = "strongSwan インスタンスに割り当てられた Elastic IP アドレス。VPN の対向設定に利用します。"
+  value       = aws_eip.cgw.public_ip
+}
+

--- a/modules/onprem-sim/variables.tf
+++ b/modules/onprem-sim/variables.tf
@@ -1,0 +1,66 @@
+###############################################
+# Variables
+# すべての入力変数に詳細な説明を付与しています。
+###############################################
+
+variable "vpc_cidr" {
+  type        = string
+  description = <<-EOT
+  VPC に割り当てる CIDR ブロック。
+  デモ用オンプレ環境全体のアドレス空間を定義します。
+  EOT
+}
+
+variable "public_subnet_cidr" {
+  type        = string
+  description = <<-EOT
+  strongSwan インスタンスを配置するパブリックサブネットの CIDR ブロック。
+  VPC 内で vpc_cidr と重複しない値を指定してください。
+  EOT
+}
+
+variable "az" {
+  type        = string
+  description = <<-EOT
+  パブリックサブネットを作成するアベイラビリティゾーン。
+  例: ap-northeast-1a
+  EOT
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.small"
+  description = <<-EOT
+  strongSwan 用 EC2 インスタンスのタイプ。
+  VPN ゲートウェイとしての基本性能を満たす t3.small を既定値としています。
+  EOT
+}
+
+variable "ami_id" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  strongSwan インスタンスに使用する AMI の ID。
+  未指定の場合は最新の Amazon Linux 2023 を自動的に選択します。
+  strongSwan がプリインストールされた AMI を利用する場合に指定してください。
+  EOT
+}
+
+variable "name_prefix" {
+  type        = string
+  default     = "onprem-sim"
+  description = <<-EOT
+  作成されるリソース名のプレフィックス。
+  複数の環境を同一アカウントで構築する際の識別に利用します。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  追加で付与するタグのマップ。
+  Provider の default_tags とマージされます。
+  EOT
+}
+


### PR DESCRIPTION
## Summary
- add onprem-sim module for demo on-prem environment
- provide minimal example usage

## Testing
- `terraform -chdir=examples/onprem-sim-minimal init -backend=false`
- `terraform -chdir=examples/onprem-sim-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c0e1fc26b8832ebaf4b29364372587