### PR TITLE
feat: workload vpce モジュールを追加

### DIFF
--- a/examples/workload-vpce-minimal/main.tf
+++ b/examples/workload-vpce-minimal/main.tf
@@ -1,0 +1,130 @@
+###############################################
+# Example: workload-vpce (minimal)
+#
+# この例では、最小限の VPC とセキュリティグループを用意し、
+# workload-vpce モジュールで ECS ワークロードに必要な
+# VPC エンドポイント群を作成します。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+###############################################
+# Provider (repo-wide standard)
+###############################################
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Inputs for this example
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名。タグに使用します。"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "環境名（例: dev, stg, prd）。タグに使用します。"
+  default     = "dev"
+}
+
+###############################################
+# Prepare AZs
+###############################################
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+###############################################
+# Step 1: VPC (from vpc-spoke)
+###############################################
+module "vpc_spoke" {
+  source = "../../modules/vpc-spoke"
+
+  name_prefix                 = "demo"
+  vpc_cidr                    = "10.20.0.0/16"
+  azs                         = slice(data.aws_availability_zones.available.names, 0, 2)
+  private_subnet_count_per_az = 1
+  subnet_newbits              = 8
+
+  tags = {
+    Project = var.app_name
+    Env     = var.env
+  }
+}
+
+###############################################
+# Step 2: Security Group for Interface VPCE
+# - VPC 内からの 443/TCP のみ許可
+###############################################
+resource "aws_security_group" "vpce" {
+  name        = "demo-vpce-sg"
+  description = "Allow HTTPS from VPC"
+  vpc_id      = module.vpc_spoke.vpc_id
+
+  ingress {
+    description = "Allow HTTPS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["10.20.0.0/16"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+###############################################
+# Step 3: Workload VPC Endpoints
+###############################################
+module "workload_vpce" {
+  source            = "../../modules/workload-vpce"
+  vpc_id            = module.vpc_spoke.vpc_id
+  subnet_ids        = flatten([for az, ids in module.vpc_spoke.private_subnet_ids_by_az : ids])
+  security_group_id = aws_security_group.vpce.id
+
+  # services を省略するとデフォルトセット(ECR, Secrets, Logs)が作成されます
+
+  tags = {
+    Project = var.app_name
+    Env     = var.env
+  }
+}
+
+###############################################
+# Helpful outputs
+###############################################
+output "endpoint_ids" {
+  value       = module.workload_vpce.endpoint_ids
+  description = "作成された VPCE の ID マップ"
+}

--- a/modules/workload-vpce/main.tf
+++ b/modules/workload-vpce/main.tf
@@ -1,0 +1,84 @@
+###############################################
+# Minimal Gov: Workload VPC Endpoints module
+#
+# このモジュールは、アプリケーション VPC（例: ECS ワークロード）
+# で必要となる最小限の VPC エンドポイントをまとめて作成します。
+#
+# - Interface 型: ECR (API/DKR)、Secrets Manager、CloudWatch Logs
+# - Gateway 型: S3
+#
+# 入力として既存 VPC の ID、プライベートサブネット IDs、
+# そしてエンドポイント ENI 用のセキュリティグループ ID を受け取ります。
+# services 変数を指定しない場合は上記デフォルトセットを作成します。
+#
+# 設計指針:
+# - ロジックは単純化し、可読性を最優先
+# - Private DNS を既定で有効化（サービス FQDN 利用のため）
+# - S3 Gateway Endpoint は指定サブネットに関連付くルートテーブルへ自動で関連付け
+# - 出力は上位モジュールが依存する最小限の ID のみ
+###############################################
+
+###############################################
+# Data sources
+###############################################
+# リージョン名を取得し、サービス名の組み立てに利用
+# また、各サブネットに関連付くルートテーブルを取得します。
+###############################################
+data "aws_region" "current" {}
+
+data "aws_route_table" "this" {
+  for_each  = toset(var.subnet_ids)
+  subnet_id = each.key
+}
+
+###############################################
+# Locals
+###############################################
+locals {
+  # サービス一覧: 引数 services が空または未指定ならデフォルトセット
+  interface_services = length(var.services) > 0 ? var.services : [
+    "ecr.api",
+    "ecr.dkr",
+    "secretsmanager",
+    "logs",
+  ]
+
+  # S3 Gateway VPCE に関連付ける一意なルートテーブル ID
+  route_table_ids = distinct([for rt in data.aws_route_table.this : rt.id])
+}
+
+###############################################
+# Interface VPC Endpoints
+# - 各サービスごとに 1 つのエンドポイントを作成
+# - Private DNS は既定で有効化
+# - セキュリティグループは外部で管理した ID を使用
+###############################################
+resource "aws_vpc_endpoint" "interface" {
+  for_each = toset(local.interface_services)
+
+  vpc_id              = var.vpc_id
+  vpc_endpoint_type   = "Interface"
+  service_name        = "com.amazonaws.${data.aws_region.current.id}.${each.key}"
+  subnet_ids          = var.subnet_ids
+  security_group_ids  = [var.security_group_id]
+  private_dns_enabled = true
+
+  tags = merge({
+    Name = "${each.key}-vpce"
+  }, var.tags)
+}
+
+###############################################
+# S3 Gateway VPC Endpoint
+# - 指定サブネットに関連付くルートテーブルへ自動で関連付けます
+###############################################
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = var.vpc_id
+  vpc_endpoint_type = "Gateway"
+  service_name      = "com.amazonaws.${data.aws_region.current.id}.s3"
+  route_table_ids   = local.route_table_ids
+
+  tags = merge({
+    Name = "s3-vpce"
+  }, var.tags)
+}

--- a/modules/workload-vpce/outputs.tf
+++ b/modules/workload-vpce/outputs.tf
@@ -1,0 +1,16 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみ出力します。
+###############################################
+
+output "endpoint_ids" {
+  description = <<-EOT
+  作成した VPC エンドポイントの ID マップ。
+  キーはサービス短縮名（例: "ecr.api", "logs", "s3"）です。
+  例: module.workload_vpce.endpoint_ids["ecr.api"]
+  EOT
+  value = merge(
+    { for k, v in aws_vpc_endpoint.interface : k => v.id },
+    { s3 = aws_vpc_endpoint.s3.id }
+  )
+}

--- a/modules/workload-vpce/variables.tf
+++ b/modules/workload-vpce/variables.tf
@@ -1,0 +1,52 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "vpc_id" {
+  type        = string
+  description = <<-EOT
+  既存 VPC の ID。すべての VPC エンドポイントはこの VPC 内に作成されます。
+  例: "vpc-0123456789abcdef0"
+  EOT
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = <<-EOT
+  Interface 型 VPC エンドポイントを配置するプライベートサブネットの ID 一覧。
+  各サブネットに関連付くルートテーブルを自動取得し、S3 Gateway エンドポイントにも使用します。
+  EOT
+}
+
+variable "security_group_id" {
+  type        = string
+  description = <<-EOT
+  Interface 型エンドポイントに適用するセキュリティグループの ID。
+  VPC 内クライアントからの 443/TCP のみを許可した最小権限 SG を渡すことを推奨します。
+  EOT
+}
+
+variable "services" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+  作成する Interface 型 VPC エンドポイントのサービス短縮名一覧。
+  未指定または空リストの場合、デフォルトで以下を作成します。
+    - ecr.api
+    - ecr.dkr
+    - secretsmanager
+    - logs
+  例: ["ecr.api", "ecr.dkr", "secretsmanager", "logs"]
+  必要に応じて追加・削除してください。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  追加で付与するタグのマップ。コンプライアンスやコスト配賦のため、
+  Project や Env などのタグ付与を推奨します。
+  EOT
+}


### PR DESCRIPTION
## 概要
- ワークロード用に必要最低限の VPC エンドポイントをまとめて作成する `workload-vpce` モジュールを追加
- 使い方を示す最小構成のサンプルを追加

## テスト
- `terraform -chdir=modules/workload-vpce init -backend=false`
- `terraform -chdir=examples/workload-vpce-minimal init -backend=false`
- `terraform -chdir=examples/workload-vpce-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c1048c60e0832ea81143be873ff9ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 最小構成でVPCとVPCエンドポイントを展開できるデプロイ例を追加。
  - ワークロード向けVPCEモジュールを追加。ECR(API/DKR)・Secrets Manager・CloudWatch Logsのインターフェイス型とS3ゲートウェイを自動作成（未指定時のデフォルト）。
  - 作成したエンドポイントIDのマップを出力し、後続リソースから参照可能。
  - サブネット/セキュリティグループ/タグなどの入力に対応。HTTPS(443)最小許可の推奨設定付き。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->