### PR TITLE
feat: WAF ACL モジュールを追加

### DIFF
--- a/examples/waf-acl-minimal/main.tf
+++ b/examples/waf-acl-minimal/main.tf
@@ -1,0 +1,67 @@
+###############################################
+# Example: waf-acl (minimal)
+#
+# この例は、本モジュールを最小限の入力で実行できる構成です。
+# - "dev" という名前の Web ACL を作成
+# - 172.16.0.0/16 のみを許可する IP Set を作成
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名（default_tags 用）"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "環境名（default_tags 用）"
+  default     = "dev"
+}
+
+module "waf_acl" {
+  source = "../../modules/waf-acl"
+
+  name        = "dev"
+  allow_cidrs = ["172.16.0.0/16"]
+}
+
+output "web_acl_arn" {
+  value       = module.waf_acl.web_acl_arn
+  description = "作成された WAF Web ACL の ARN"
+}
+
+output "ip_set_arn" {
+  value       = module.waf_acl.ip_set_arn
+  description = "許可 CIDR を登録した IP Set の ARN"
+}
+

--- a/modules/waf-acl/main.tf
+++ b/modules/waf-acl/main.tf
@@ -1,0 +1,95 @@
+###############################################
+# Minimal Gov: WAF ACL module
+#
+# このモジュールは、指定した CIDR からのみアクセスを許可する
+# AWS WAFv2 Web ACL を作成します。
+# - 許可 IP セット (aws_wafv2_ip_set)
+# - 上記 IP セットを許可し、それ以外を遮断する Web ACL (aws_wafv2_web_acl)
+#
+# 主な用途:
+# - ALB / API Gateway / AppSync など REGIONAL スコープのリソースに紐付け
+# - ユーザ拠点など特定 CIDR のみにアクセスを制限
+#
+# 設計指針:
+# - ロジックはできるだけ単純化
+# - 変数化と豊富なコメントで可読性を重視
+# - セキュリティ既定値: 許可リスト外のアクセスは Block
+###############################################
+
+###############################################
+# Locals
+# - base_name はリソース名やタグに利用する共通プレフィックス
+###############################################
+locals {
+  base_name = var.name
+}
+
+###############################################
+# 許可 IP セット
+# - allow_cidrs で指定した CIDR のみを登録
+# - IPv4 のみを想定（必要に応じてモジュール拡張）
+###############################################
+resource "aws_wafv2_ip_set" "allow" {
+  name               = "${local.base_name}-allow"
+  description        = "許可されたクライアント CIDR セット"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses          = var.allow_cidrs
+
+  tags = merge(
+    {
+      Name = "${local.base_name}-allow-ipset"
+    },
+    var.tags,
+  )
+}
+
+###############################################
+# Web ACL 本体
+# - デフォルトでは全トラフィックを Block
+# - allow-cidr ルールで IP セット内のみ Allow
+###############################################
+resource "aws_wafv2_web_acl" "this" {
+  name        = "${local.base_name}-acl"
+  description = "allow_cidrs で指定した範囲のみを許可する WAF ACL"
+  scope       = "REGIONAL"
+
+  default_action {
+    block {}
+  }
+
+  rule {
+    name     = "allow-cidr"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.allow.arn
+      }
+    }
+
+    visibility_config {
+      metric_name                = "${local.base_name}-allow-cidr"
+      cloudwatch_metrics_enabled = true # 標準で CloudWatch メトリクスを有効化
+      sampled_requests_enabled   = true # 代表リクエストを記録（トラブルシュートに有用）
+    }
+  }
+
+  visibility_config {
+    metric_name                = local.base_name
+    cloudwatch_metrics_enabled = true
+    sampled_requests_enabled   = true
+  }
+
+  tags = merge(
+    {
+      Name = "${local.base_name}-acl"
+    },
+    var.tags,
+  )
+}
+

--- a/modules/waf-acl/outputs.tf
+++ b/modules/waf-acl/outputs.tf
@@ -1,0 +1,23 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみ出力します。
+# 利用方法のヒントをコメントとして併記します。
+###############################################
+
+output "web_acl_arn" {
+  description = <<-EOT
+  作成された WAF Web ACL の ARN。
+  例: ALB や API Gateway v2 で WAF を有効化する際に
+  `waf_acl_arn = module.waf_acl.web_acl_arn` のように渡します。
+  EOT
+  value       = aws_wafv2_web_acl.this.arn
+}
+
+output "ip_set_arn" {
+  description = <<-EOT
+  許可 CIDR を登録した IP Set の ARN。
+  CLI や別モジュールからアドレスを追加/削除したい場合に参照します。
+  EOT
+  value       = aws_wafv2_ip_set.allow.arn
+}
+

--- a/modules/waf-acl/variables.tf
+++ b/modules/waf-acl/variables.tf
@@ -1,0 +1,43 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "name" {
+  type        = string
+  description = <<-EOT
+  Web ACL および関連リソースの論理名。
+  - 例: "dev" を指定すると Web ACL 名は "dev-acl" となります。
+  Name タグやメトリクス名にも利用します。
+  EOT
+
+  validation {
+    condition     = length(var.name) > 0
+    error_message = "name は 1 文字以上で指定してください。"
+  }
+}
+
+variable "allow_cidrs" {
+  type        = list(string)
+  description = <<-EOT
+  アクセスを許可する IPv4 CIDR ブロックの一覧。
+  - 例: ["203.0.113.0/24", "198.51.100.10/32"]
+  指定された範囲のみ ALLOW とし、それ以外は Block されます。
+  EOT
+
+  validation {
+    condition     = length(var.allow_cidrs) > 0 && alltrue([for c in var.allow_cidrs : can(cidrnetmask(c))])
+    error_message = "allow_cidrs には 1 つ以上の有効な IPv4 CIDR を指定してください。"
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  追加で付与するタグのマップ。
+  プロバイダの default_tags とマージされます。
+  例: { Project = "minimal-gov", Owner = "network-team" }
+  EOT
+}
+


### PR DESCRIPTION
## 概要
- 固定 CIDR のみを許可する WAFv2 Web ACL モジュールを追加
- 上記モジュールの最小実行例を examples に追加

## テスト
- `terraform init -backend=false` (modules/waf-acl)
- `terraform validate` (modules/waf-acl)
- `terraform init -backend=false` (examples/waf-acl-minimal)
- `terraform validate` (examples/waf-acl-minimal)


------
https://chatgpt.com/codex/tasks/task_e_68c104af7500832ea4b705e0cd509763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 最小構成のWAF ACLモジュールを追加し、IPv4 CIDRの許可リストでアクセス制御を提供
  - リージョナルスコープ対応、ルール/ACLのCloudWatchメトリクス有効化
  - 出力としてWeb ACL ARNとIP Set ARNを提供し、他リソースから参照可能
  - 変数で名前・許可CIDR・タグを指定可能

- ドキュメント
  - 最小構成の利用例を追加し、設定例と出力の参照方法を提示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->