### PR TITLE
feat: RDS モジュールを追加

### DIFF
--- a/examples/rds-minimal/main.tf
+++ b/examples/rds-minimal/main.tf
@@ -1,0 +1,118 @@
+###############################################
+# Example: rds (minimal)
+#
+# この例は、本モジュールを最小限の構成で利用する方法を示します。
+# - 単純な VPC と 2 つのプライベートサブネットを作成
+# - そのサブネット上に MySQL RDS インスタンスを 1 台構築
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+variable "region" {
+  description = "デプロイ先リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  description = "アプリケーション名（タグ用）"
+  type        = string
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  description = "環境名（タグ用）"
+  type        = string
+  default     = "dev"
+}
+
+###############################################
+# VPC とプライベートサブネット
+###############################################
+resource "aws_vpc" "this" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_subnet" "private_a" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.region}a"
+  map_public_ip_on_launch = false
+}
+
+resource "aws_subnet" "private_c" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "${var.region}c"
+  map_public_ip_on_launch = false
+}
+
+resource "aws_security_group" "rds" {
+  name   = "rds-sg"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    description = "allow MySQL from VPC"
+    from_port   = 3306
+    to_port     = 3306
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.this.cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+###############################################
+# RDS Module
+###############################################
+module "rds" {
+  source = "../../modules/rds"
+
+  subnet_ids             = [aws_subnet.private_a.id, aws_subnet.private_c.id]
+  vpc_security_group_ids = [aws_security_group.rds.id]
+  username               = "admin"
+  password               = "P@ssw0rd123"
+  db_name                = "demo"
+  deletion_protection    = false # 例のため削除保護を無効化
+  skip_final_snapshot    = true  # 例のためスナップショットを取得せず削除
+
+  tags = {
+    Project = "minimal-gov"
+    Env     = "dev"
+  }
+}
+
+output "db_endpoint" {
+  value       = module.rds.db_instance_endpoint
+  description = "作成された RDS の接続エンドポイント"
+}
+

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -1,0 +1,61 @@
+###############################################
+# Minimal Gov: RDS module
+#
+# このモジュールは Amazon RDS の単一 DB インスタンスを作成します。
+# - 指定されたサブネット群に DB サブネットグループを構成
+# - ストレージ暗号化やパブリックアクセス無効化を既定で有効化
+# - 最小限の入力で安全な RDS を構築可能
+###############################################
+
+###############################################
+# Locals
+###############################################
+locals {
+  # name_prefix は未指定なら "rds" を利用
+  name_prefix = var.name_prefix != null && var.name_prefix != "" ? var.name_prefix : "rds"
+}
+
+###############################################
+# DB Subnet Group
+# - RDS が配置されるサブネットをまとめる
+###############################################
+resource "aws_db_subnet_group" "this" {
+  name        = "${local.name_prefix}-subnet-group"
+  description = "Subnets for RDS ${local.name_prefix}"
+  subnet_ids  = var.subnet_ids
+
+  tags = merge({
+    Name = "${local.name_prefix}-subnet-group"
+  }, var.tags)
+}
+
+###############################################
+# RDS DB Instance
+# - 単一インスタンスの DB を作成
+# - ストレージ暗号化、公衆アクセス無効化、削除保護などを既定で有効化
+###############################################
+resource "aws_db_instance" "this" {
+  identifier             = "${local.name_prefix}-db"
+  engine                 = var.engine
+  engine_version         = var.engine_version
+  instance_class         = var.instance_class
+  allocated_storage      = var.allocated_storage
+  db_subnet_group_name   = aws_db_subnet_group.this.name
+  vpc_security_group_ids = var.vpc_security_group_ids
+  db_name                = var.db_name
+  username               = var.username
+  password               = var.password
+
+  multi_az                = var.multi_az
+  publicly_accessible     = false # パブリックネットワークからのアクセスを禁止
+  storage_encrypted       = true  # AWS 既定 KMS キーで暗号化
+  backup_retention_period = var.backup_retention_days
+  deletion_protection     = var.deletion_protection
+  skip_final_snapshot     = var.skip_final_snapshot
+  apply_immediately       = var.apply_immediately
+
+  tags = merge({
+    Name = "${local.name_prefix}-db"
+  }, var.tags)
+}
+

--- a/modules/rds/outputs.tf
+++ b/modules/rds/outputs.tf
@@ -1,0 +1,15 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみ出力します。
+###############################################
+
+output "db_instance_endpoint" {
+  description = "RDS インスタンスへの接続エンドポイント。例: アプリケーションの DB ホストとして module.rds.db_instance_endpoint を指定。"
+  value       = aws_db_instance.this.endpoint
+}
+
+output "db_instance_identifier" {
+  description = "作成された RDS インスタンスの識別子。運用監視や追加設定の参照に使用します。"
+  value       = aws_db_instance.this.id
+}
+

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -1,0 +1,146 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "name_prefix" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  リソース名や Name タグに付与する任意のプレフィックス。
+  未指定（null/空文字）の場合は "rds" を使用します。
+  EOT
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = <<-EOT
+  RDS を配置するサブネット ID のリスト。
+  異なる AZ に属する最低 2 つのプライベートサブネットを指定してください。
+  EOT
+}
+
+variable "vpc_security_group_ids" {
+  type        = list(string)
+  description = <<-EOT
+  RDS インスタンスに関連付けるセキュリティグループの ID リスト。
+  アプリケーションからの接続を許可するルールを事前に設定してください。
+  EOT
+}
+
+variable "engine" {
+  type        = string
+  default     = "mysql"
+  description = <<-EOT
+  利用するデータベースエンジン種別。
+  例: "mysql", "postgres", "mariadb" など。
+  EOT
+}
+
+variable "engine_version" {
+  type        = string
+  default     = "8.0"
+  description = <<-EOT
+  データベースエンジンのバージョン。
+  固定したいバージョンがある場合に指定します。
+  EOT
+}
+
+variable "instance_class" {
+  type        = string
+  default     = "db.t3.micro"
+  description = <<-EOT
+  RDS インスタンスのクラス。
+  小規模用途では db.t3.micro などのバースト系がコスト効率に優れます。
+  EOT
+}
+
+variable "allocated_storage" {
+  type        = number
+  default     = 20
+  description = <<-EOT
+  プロビジョニングするストレージ容量 (GiB)。
+  多くのエンジンで最小 20GiB が必要です。
+  EOT
+}
+
+variable "db_name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  初期作成するデータベース名。
+  指定しない場合はデータベースを自動作成しません。
+  EOT
+}
+
+variable "username" {
+  type        = string
+  description = <<-EOT
+  マスターユーザー名。
+  機密情報のため、変数ファイルやシークレットマネージャー経由で指定することを推奨します。
+  EOT
+}
+
+variable "password" {
+  type        = string
+  sensitive   = true
+  description = <<-EOT
+  マスターパスワード。
+  tfstate に平文で保存されるため、保管場所には十分注意してください。
+  EOT
+}
+
+variable "multi_az" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  マルチ AZ 配置を有効にするかどうか。
+  高可用性が必要な場合に true を指定します。
+  EOT
+}
+
+variable "backup_retention_days" {
+  type        = number
+  default     = 7
+  description = <<-EOT
+  自動バックアップの保持日数。
+  0 を指定するとバックアップを無効化します。
+  EOT
+}
+
+variable "deletion_protection" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  誤削除を防ぐための削除保護を有効にするかどうか。
+  本番環境では true を推奨します。
+  EOT
+}
+
+variable "skip_final_snapshot" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  RDS インスタンス削除時に最終スナップショットを取得するかどうか。
+  true にするとスナップショットを取得せず即時削除します。
+  EOT
+}
+
+variable "apply_immediately" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+  パラメータ変更を即時適用するかどうか。
+  false にするとメンテナンスウィンドウまで待機します。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  すべてのリソースに付与する共通タグ。
+  例: { Project = "minimal-gov", Env = "dev" }
+  EOT
+}
+


### PR DESCRIPTION
## 概要
- RDS インスタンスを構築するモジュールを追加
- 最小構成の利用例を追加

## テスト
- `terraform -chdir=examples/rds-minimal init -backend=false`
- `terraform -chdir=examples/rds-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c104bd1984832ebac9c4836152ed46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - RDS 構築用の最小 Terraform サンプルを追加（VPC・プライベートサブネット・MySQL 用 SG を含む）。
  - 再利用可能な RDS モジュールを追加し、非公開アクセス・ストレージ暗号化・バックアップ保持を標準設定。
  - モジュール出力として DB エンドポイントおよびインスタンス識別子を提供。
  - エンジン/バージョン/インスタンスタイプ/ストレージ/サブネット/SG/マルチ AZ/タグ等を変数で柔軟に設定可能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->