### PR TITLE
feat: observability baseline モジュールを追加

### DIFF
--- a/examples/observability-baseline-minimal/main.tf
+++ b/examples/observability-baseline-minimal/main.tf
@@ -1,0 +1,82 @@
+###############################################
+# Example: observability-baseline (minimal)
+#
+# この例では、既存の ALB / ECS サービス / RDS インスタンスに対して
+# 代表的な CloudWatch アラームとダッシュボードを作成します。
+# 実際のリソース名に置き換えることでそのまま適用できます。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Variables for example
+###############################################
+
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application タグに使用する名称"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment タグ用の値"
+  default     = "dev"
+}
+
+###############################################
+# Module invocation
+###############################################
+
+module "observability" {
+  source = "../../modules/observability-baseline"
+
+  alb_arn_suffix   = "app/sample/1234567890abcdef" # 実際の ALB arn_suffix に置き換え
+  ecs_cluster_name = "sample-cluster"              # 実際のクラスター名に置き換え
+  ecs_service_name = "sample-service"              # 実際のサービス名に置き換え
+  rds_identifier   = "sample-db"                   # 実際の DB インスタンス識別子に置き換え
+  # sns_topic_arn  = "arn:aws:sns:ap-northeast-1:123456789012:notify"  # 任意: 通知先 SNS トピック
+}
+
+###############################################
+# Outputs
+###############################################
+
+output "dashboard_name" {
+  description = "作成された CloudWatch ダッシュボードの名前"
+  value       = module.observability.dashboard_name
+}
+
+output "alarm_arns" {
+  description = "作成された CloudWatch アラームの ARN 一覧"
+  value       = module.observability.alarm_arns
+}
+

--- a/modules/observability-baseline/main.tf
+++ b/modules/observability-baseline/main.tf
@@ -1,0 +1,212 @@
+###############################################
+# Minimal Gov: Observability Baseline module
+#
+# このモジュールは ALB, ECS, RDS 向けの代表的な CloudWatch
+# アラームとダッシュボードを作成し、監視の最低限の基盤を
+# 提供します。
+#
+# 作成されるリソース:
+# - ALB 5xx エラー検知用 CloudWatch アラーム
+# - ECS サービス CPU/メモリ使用率アラーム
+# - RDS 空きストレージ/接続数アラーム
+# - 上記メトリクスをまとめた CloudWatch ダッシュボード
+#
+# 設計方針:
+# - ロジックを簡潔に保ち、詳細なコメントを付与する
+# - アラーム通知には SNS トピックをオプションで設定
+# - 出力はダッシュボード名とアラーム ARN のみに限定
+###############################################
+
+locals {
+  # SNS トピック ARN が指定されている場合のみアラーム通知を有効化
+  alarm_actions = var.sns_topic_arn != null && var.sns_topic_arn != "" ? [var.sns_topic_arn] : []
+
+  # ALB ARN サフィックスはそのまま CloudWatch の LoadBalancer 次元に使用
+  alb_dimension = var.alb_arn_suffix
+}
+
+###############################################
+# CloudWatch Alarms
+###############################################
+
+# ALB の 5xx エラー数がしきい値を超えた場合に通知
+resource "aws_cloudwatch_metric_alarm" "alb_5xx" {
+  alarm_name          = "alb-5xx"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = 60
+  statistic           = "Sum"
+  threshold           = var.alb_5xx_threshold
+  dimensions = {
+    LoadBalancer = local.alb_dimension
+  }
+  alarm_description = "ALB の 5xx エラー数がしきい値 (${var.alb_5xx_threshold}) を超えた場合にアラートを送信します。"
+  alarm_actions     = local.alarm_actions
+}
+
+# ECS サービスの CPU 使用率がしきい値を超えた場合に通知
+resource "aws_cloudwatch_metric_alarm" "ecs_cpu_high" {
+  alarm_name          = "ecs-cpu-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.ecs_cpu_threshold
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+  alarm_description = "ECS サービスの CPU 使用率がしきい値 (${var.ecs_cpu_threshold}%) を超えた場合にアラートを送信します。"
+  alarm_actions     = local.alarm_actions
+}
+
+# ECS サービスのメモリ使用率がしきい値を超えた場合に通知
+resource "aws_cloudwatch_metric_alarm" "ecs_memory_high" {
+  alarm_name          = "ecs-memory-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "MemoryUtilization"
+  namespace           = "AWS/ECS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = var.ecs_memory_threshold
+  dimensions = {
+    ClusterName = var.ecs_cluster_name
+    ServiceName = var.ecs_service_name
+  }
+  alarm_description = "ECS サービスのメモリ使用率がしきい値 (${var.ecs_memory_threshold}%) を超えた場合にアラートを送信します。"
+  alarm_actions     = local.alarm_actions
+}
+
+# RDS インスタンスの空きストレージ容量がしきい値を下回った場合に通知
+resource "aws_cloudwatch_metric_alarm" "rds_free_storage_low" {
+  alarm_name          = "rds-free-storage-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.rds_free_storage_threshold
+  dimensions = {
+    DBInstanceIdentifier = var.rds_identifier
+  }
+  alarm_description = "RDS の空きストレージがしきい値 (${var.rds_free_storage_threshold} バイト) を下回った場合にアラートを送信します。"
+  alarm_actions     = local.alarm_actions
+  unit              = "Bytes"
+}
+
+# RDS インスタンスの接続数がしきい値を超えた場合に通知
+resource "aws_cloudwatch_metric_alarm" "rds_connections_high" {
+  alarm_name          = "rds-connections-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = var.rds_connections_threshold
+  dimensions = {
+    DBInstanceIdentifier = var.rds_identifier
+  }
+  alarm_description = "RDS の接続数がしきい値 (${var.rds_connections_threshold}) を超えた場合にアラートを送信します。"
+  alarm_actions     = local.alarm_actions
+}
+
+###############################################
+# CloudWatch Dashboard
+###############################################
+
+locals {
+  # ダッシュボードに表示するメトリクス定義
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        x      = 0
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title = "ALB 5xx"
+          metrics = [
+            ["AWS/ApplicationELB", "HTTPCode_Target_5XX_Count", "LoadBalancer", local.alb_dimension]
+          ]
+          period = 60
+          stat   = "Sum"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 0
+        width  = 12
+        height = 6
+        properties = {
+          title = "ECS CPU"
+          metrics = [
+            ["AWS/ECS", "CPUUtilization", "ClusterName", var.ecs_cluster_name, "ServiceName", var.ecs_service_name]
+          ]
+          period = 60
+          stat   = "Average"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title = "ECS Memory"
+          metrics = [
+            ["AWS/ECS", "MemoryUtilization", "ClusterName", var.ecs_cluster_name, "ServiceName", var.ecs_service_name]
+          ]
+          period = 60
+          stat   = "Average"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 12
+        y      = 6
+        width  = 12
+        height = 6
+        properties = {
+          title = "RDS FreeStorage"
+          metrics = [
+            ["AWS/RDS", "FreeStorageSpace", "DBInstanceIdentifier", var.rds_identifier]
+          ]
+          period = 300
+          stat   = "Average"
+        }
+      },
+      {
+        type   = "metric"
+        x      = 0
+        y      = 12
+        width  = 12
+        height = 6
+        properties = {
+          title = "RDS Connections"
+          metrics = [
+            ["AWS/RDS", "DatabaseConnections", "DBInstanceIdentifier", var.rds_identifier]
+          ]
+          period = 300
+          stat   = "Average"
+        }
+      }
+    ]
+  })
+}
+
+# 可観測性ダッシュボードを作成
+resource "aws_cloudwatch_dashboard" "this" {
+  dashboard_name = var.dashboard_name
+  dashboard_body = local.dashboard_body
+}
+

--- a/modules/observability-baseline/outputs.tf
+++ b/modules/observability-baseline/outputs.tf
@@ -1,0 +1,21 @@
+###############################################
+# Outputs
+# 呼び出し側が参照する必要最低限の値のみ公開します。
+###############################################
+
+output "dashboard_name" {
+  description = "作成された CloudWatch ダッシュボードの名前。コンソールからの参照に使用します。"
+  value       = aws_cloudwatch_dashboard.this.dashboard_name
+}
+
+output "alarm_arns" {
+  description = "作成された CloudWatch アラームの ARN 一覧。通知設定やアクセス制御の参照に使用します。"
+  value = [
+    aws_cloudwatch_metric_alarm.alb_5xx.arn,
+    aws_cloudwatch_metric_alarm.ecs_cpu_high.arn,
+    aws_cloudwatch_metric_alarm.ecs_memory_high.arn,
+    aws_cloudwatch_metric_alarm.rds_free_storage_low.arn,
+    aws_cloudwatch_metric_alarm.rds_connections_high.arn,
+  ]
+}
+

--- a/modules/observability-baseline/variables.tf
+++ b/modules/observability-baseline/variables.tf
@@ -1,0 +1,102 @@
+###############################################
+# Variables
+# すべての入力に詳細な説明を付与します。
+###############################################
+
+variable "alb_arn_suffix" {
+  type        = string
+  description = <<-EOT
+  監視対象とする Application Load Balancer の ARN サフィックス。
+  例: "app/example/1234567890abcdef"。
+  CloudWatch メトリクスの LoadBalancer 次元に使用されます。
+  EOT
+}
+
+variable "ecs_cluster_name" {
+  type        = string
+  description = <<-EOT
+  監視対象の ECS クラスター名。
+  CPU / メモリ利用率アラームおよびダッシュボードの次元に使用されます。
+  EOT
+}
+
+variable "ecs_service_name" {
+  type        = string
+  description = <<-EOT
+  監視対象の ECS サービス名。
+  CPU / メモリ利用率アラームおよびダッシュボードの次元に使用されます。
+  EOT
+}
+
+variable "rds_identifier" {
+  type        = string
+  description = <<-EOT
+  監視対象の RDS インスタンス識別子 (DBInstanceIdentifier)。
+  空きストレージ量と接続数アラームの次元に使用されます。
+  EOT
+}
+
+variable "sns_topic_arn" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  アラーム通知を送信する SNS トピックの ARN。
+  指定しない場合、アラームの通知アクションは設定されません。
+  EOT
+}
+
+variable "alb_5xx_threshold" {
+  type        = number
+  default     = 1
+  description = <<-EOT
+  ALB の 5xx エラー数アラームのしきい値。
+  1 分間に記録される合計値がこの値を超えるとアラームが発火します。
+  EOT
+}
+
+variable "ecs_cpu_threshold" {
+  type        = number
+  default     = 80
+  description = <<-EOT
+  ECS サービスの CPU 使用率アラームのしきい値 (パーセント)。
+  1 分間の平均値がこの値を超えるとアラームが発火します。
+  EOT
+}
+
+variable "ecs_memory_threshold" {
+  type        = number
+  default     = 80
+  description = <<-EOT
+  ECS サービスのメモリ使用率アラームのしきい値 (パーセント)。
+  1 分間の平均値がこの値を超えるとアラームが発火します。
+  EOT
+}
+
+variable "rds_free_storage_threshold" {
+  type        = number
+  default     = 21474836480
+  description = <<-EOT
+  RDS の空きストレージ容量アラームのしきい値 (バイト)。
+  5 分間の平均値がこの値を下回るとアラームが発火します。
+  デフォルトは約 20GB です。
+  EOT
+}
+
+variable "rds_connections_threshold" {
+  type        = number
+  default     = 100
+  description = <<-EOT
+  RDS のデータベース接続数アラームのしきい値。
+  5 分間の平均値がこの値を超えるとアラームが発火します。
+  EOT
+}
+
+variable "dashboard_name" {
+  type        = string
+  default     = "observability-baseline"
+  description = <<-EOT
+  作成する CloudWatch ダッシュボードの名前。
+  複数環境で併用する場合は一意な名称を指定してください。
+  EOT
+}
+


### PR DESCRIPTION
## 概要
- ALB/ECS/RDS 向けの代表的な CloudWatch アラームとダッシュボードを作成する `observability-baseline` モジュールを追加
- しきい値や SNS 通知先を変数化し、必要最小限の出力を提供
- 利用例として `examples/observability-baseline-minimal` を追加

## テスト
- `terraform fmt modules/observability-baseline/main.tf modules/observability-baseline/variables.tf modules/observability-baseline/outputs.tf examples/observability-baseline-minimal/main.tf`
- `terraform -chdir=examples/observability-baseline-minimal init`
- `terraform -chdir=examples/observability-baseline-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c1052e8c90832e838cf84c28271391

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - ALB/ECS/RDS を対象にした最小構成の監視ベースラインを追加。CloudWatch ダッシュボードと主要メトリクスのアラームを自動作成。
  - SNS 通知は任意で有効化可能。各種しきい値やダッシュボード名を入力変数で調整可能。
  - 出力としてダッシュボード名とアラーム ARN 一覧を提供。
  - Terraform と AWS プロバイダのバージョン要件を追加。
- ドキュメント
  - 使い方の例と日本語コメントを追加し、必要な置換箇所・設定項目をガイド。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->