### PR TITLE
feat: DBダンプをS3へ保存するモジュール追加

### DIFF
--- a/examples/db-dump-to-s3-minimal/main.tf
+++ b/examples/db-dump-to-s3-minimal/main.tf
@@ -1,0 +1,133 @@
+###############################################
+# Example: db-dump-to-s3 (minimal)
+#
+# この例では、最小限のリソースで DB ダンプをスケジュール実行し
+# S3 へ保存するモジュールの使い方を示します。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Example variables
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application タグに使用する名称"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "Environment タグ用の値"
+  default     = "dev"
+}
+
+###############################################
+# Prerequisite resources
+###############################################
+# デフォルト VPC とそのサブネットを利用します。
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+# タスク用のセキュリティグループ (全通信許可)
+resource "aws_security_group" "db_dump" {
+  name   = "db-dump-sg"
+  vpc_id = data.aws_vpc.default.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ダンプ保存先 S3 バケット (実際の運用ではユニークな名前に変更してください)
+resource "aws_s3_bucket" "dump" {
+  bucket        = "${var.app_name}-${var.env}-db-dump"
+  force_destroy = true
+}
+
+# RDS 接続情報のダミー Secret
+resource "aws_secretsmanager_secret" "db" {
+  name = "${var.app_name}-${var.env}-db-secret"
+}
+
+resource "aws_secretsmanager_secret_version" "db" {
+  secret_id = aws_secretsmanager_secret.db.id
+  secret_string = jsonencode({
+    username = "user"
+    password = "pass"
+    host     = "db.example.com"
+    port     = 5432
+    dbname   = "app"
+  })
+}
+
+###############################################
+# Module invocation
+###############################################
+module "db_dump" {
+  source = "../../modules/db-dump-to-s3"
+
+  subnet_ids          = data.aws_subnets.default.ids
+  security_group_id   = aws_security_group.db_dump.id
+  vpc_id              = data.aws_vpc.default.id
+  rds_secret_arn      = aws_secretsmanager_secret.db.arn
+  engine              = "postgresql"
+  s3_bucket           = aws_s3_bucket.dump.bucket
+  s3_prefix           = "daily"
+  schedule_expression = "rate(1 day)"
+  task_cpu            = 256
+  task_memory         = 512
+}
+
+###############################################
+# Outputs
+###############################################
+output "rule_arn" {
+  value       = module.db_dump.rule_arn
+  description = "EventBridge ルールの ARN"
+}
+
+output "task_definition_arn" {
+  value       = module.db_dump.task_definition_arn
+  description = "ECS タスク定義の ARN"
+}
+

--- a/modules/db-dump-to-s3/main.tf
+++ b/modules/db-dump-to-s3/main.tf
@@ -1,0 +1,199 @@
+###############################################
+# Minimal Gov: db-dump-to-s3 module
+#
+# このモジュールは以下のリソースを作成します:
+# - ECS クラスターとタスク定義 (Fargate)
+# - pg_dump / mysqldump を実行するコンテナ定義
+# - CloudWatch Logs ロググループ
+# - Secrets Manager から DB 接続情報を取得し S3 へ暗号化保存する IAM ロール
+# - EventBridge ルール & ターゲット (スケジュール起動)
+#
+# 利用者は、RDS の接続情報を保持した Secrets Manager の ARN と
+# 出力先 S3 バケット/プレフィックスを渡すだけで、DB の論理ダンプを
+# 定期的に S3 へ保存できます。
+###############################################
+
+data "aws_region" "current" {}
+
+locals {
+  # 利用するコンテナイメージ。
+  # AWS が提供する database-tools イメージにはクライアントと AWS CLI が含まれる。
+  image = var.engine == "postgresql" ? "public.ecr.aws/aws-database-tools/pg:latest" : "public.ecr.aws/aws-database-tools/mysql:latest"
+
+  # 実行コマンド。DB からダンプを取得し gzip 圧縮後 S3 へアップロードします。
+  postgres_cmd = "PGPASSWORD=$$DB_PASSWORD pg_dump -h $$DB_HOST -p $$DB_PORT -U $$DB_USERNAME $$DB_NAME | gzip | aws s3 cp - s3://%s/%s/$(date +%%Y-%%m-%%dT%%H-%%M-%%S).sql.gz"
+  mysql_cmd    = "mysqldump -h $$DB_HOST -P $$DB_PORT -u $$DB_USERNAME -p$$DB_PASSWORD $$DB_NAME | gzip | aws s3 cp - s3://%s/%s/$(date +%%Y-%%m-%%dT%%H-%%M-%%S).sql.gz"
+
+  dump_command = var.engine == "postgresql" ? format(local.postgres_cmd, var.s3_bucket, var.s3_prefix) : format(local.mysql_cmd, var.s3_bucket, var.s3_prefix)
+}
+
+###############################################
+# CloudWatch Logs: コンテナの実行ログを保存
+###############################################
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/minimal-gov/db-dump"
+  retention_in_days = 30
+}
+
+###############################################
+# IAM ロール: タスク実行 & アプリケーション
+###############################################
+# Fargate タスクの実行ロール (イメージ取得やログ出力用)
+resource "aws_iam_role" "execution" {
+  name_prefix = "db-dump-exec-"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# コンテナが使用するタスクロール
+resource "aws_iam_role" "task" {
+  name_prefix = "db-dump-task-"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+data "aws_iam_policy_document" "task" {
+  statement {
+    sid       = "SecretAccess"
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [var.rds_secret_arn]
+  }
+
+  statement {
+    sid       = "S3Write"
+    actions   = ["s3:PutObject"]
+    resources = ["arn:aws:s3:::${var.s3_bucket}/${var.s3_prefix}*"]
+  }
+}
+
+resource "aws_iam_role_policy" "task" {
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.task.json
+}
+
+###############################################
+# ECS クラスターとタスク定義
+###############################################
+resource "aws_ecs_cluster" "this" {
+  name = "db-dump"
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = "db-dump"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "dump"
+      image     = local.image
+      essential = true
+      command   = ["/bin/sh", "-c", local.dump_command]
+
+      environment = [
+        { name = "S3_BUCKET", value = var.s3_bucket },
+        { name = "S3_PREFIX", value = var.s3_prefix }
+      ]
+
+      secrets = [
+        { name = "DB_USERNAME", valueFrom = "${var.rds_secret_arn}:username::" },
+        { name = "DB_PASSWORD", valueFrom = "${var.rds_secret_arn}:password::" },
+        { name = "DB_HOST", valueFrom = "${var.rds_secret_arn}:host::" },
+        { name = "DB_PORT", valueFrom = "${var.rds_secret_arn}:port::" },
+        { name = "DB_NAME", valueFrom = "${var.rds_secret_arn}:dbname::" }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.this.name
+          awslogs-region        = data.aws_region.current.name
+          awslogs-stream-prefix = "db-dump"
+        }
+      }
+    }
+  ])
+}
+
+###############################################
+# EventBridge: スケジュール実行
+###############################################
+resource "aws_cloudwatch_event_rule" "this" {
+  name                = "db-dump-schedule"
+  description         = "Schedule DB dump task"
+  schedule_expression = var.schedule_expression
+}
+
+# EventBridge が RunTask を実行する際に利用するロール
+resource "aws_iam_role" "eventbridge" {
+  name_prefix = "db-dump-ev-"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "events.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+data "aws_iam_policy_document" "eventbridge" {
+  statement {
+    actions   = ["ecs:RunTask"]
+    resources = [aws_ecs_task_definition.this.arn]
+  }
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.execution.arn, aws_iam_role.task.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "eventbridge" {
+  role   = aws_iam_role.eventbridge.id
+  policy = data.aws_iam_policy_document.eventbridge.json
+}
+
+resource "aws_cloudwatch_event_target" "this" {
+  rule      = aws_cloudwatch_event_rule.this.name
+  target_id = "db-dump"
+  arn       = aws_ecs_cluster.this.arn
+  role_arn  = aws_iam_role.eventbridge.arn
+
+  ecs_target {
+    launch_type         = "FARGATE"
+    platform_version    = "LATEST"
+    task_definition_arn = aws_ecs_task_definition.this.arn
+    network_configuration {
+      subnets          = var.subnet_ids
+      security_groups  = [var.security_group_id]
+      assign_public_ip = false
+    }
+  }
+}
+
+###############################################
+# その他
+###############################################
+# 現時点では追加の出力用リソースはありません。
+###############################################

--- a/modules/db-dump-to-s3/outputs.tf
+++ b/modules/db-dump-to-s3/outputs.tf
@@ -1,0 +1,15 @@
+###############################################
+# Outputs
+# 呼び出し元が依存する最小限の値のみを公開します。
+###############################################
+
+output "rule_arn" {
+  description = "EventBridge ルールの ARN。必要に応じて権限付与や監視設定で参照します。"
+  value       = aws_cloudwatch_event_rule.this.arn
+}
+
+output "task_definition_arn" {
+  description = "作成された ECS タスク定義の ARN。問題調査や再利用時に参照します。"
+  value       = aws_ecs_task_definition.this.arn
+}
+

--- a/modules/db-dump-to-s3/variables.tf
+++ b/modules/db-dump-to-s3/variables.tf
@@ -1,0 +1,92 @@
+###############################################
+# Variables
+# すべての入力変数に丁寧な説明を付与します。
+###############################################
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = <<-EOT
+  Fargate タスクを配置するサブネット ID のリスト。
+  通常はプライベートサブネットを指定し、少なくとも 2 つの AZ を含めると可用性が高まります。
+  EOT
+}
+
+variable "security_group_id" {
+  type        = string
+  description = <<-EOT
+  タスクにアタッチするセキュリティグループ ID。
+  DB へのアクセスに必要なインバウンドルールを設定したものを渡してください。
+  EOT
+}
+
+variable "vpc_id" {
+  type        = string
+  description = <<-EOT
+  上記サブネットおよびセキュリティグループが属する VPC の ID。
+  直接参照はしませんが、ドキュメント上の明示のため入力として受け取ります。
+  EOT
+}
+
+variable "rds_secret_arn" {
+  type        = string
+  description = <<-EOT
+  RDS 接続情報を保持した Secrets Manager シークレットの ARN。
+  シークレットは JSON 形式で `username`, `password`, `host`, `port`, `dbname`
+  のキーを含んでいる必要があります。
+  EOT
+}
+
+variable "engine" {
+  type        = string
+  description = <<-EOT
+  ダンプ対象のデータベースエンジン。
+  `postgresql` または `mysql` のいずれかを指定してください。
+  指定値に応じて使用するコンテナイメージとダンプコマンドが切り替わります。
+  EOT
+
+  validation {
+    condition     = contains(["postgresql", "mysql"], var.engine)
+    error_message = "engine は 'postgresql' か 'mysql' のみ指定可能です。"
+  }
+}
+
+variable "s3_bucket" {
+  type        = string
+  description = <<-EOT
+  ダンプファイルを保存する既存 S3 バケット名。
+  バケット側ではサーバーサイド暗号化 (SSE-KMS など) を有効にしておくことを推奨します。
+  EOT
+}
+
+variable "s3_prefix" {
+  type        = string
+  description = <<-EOT
+  S3 バケット内での保存プレフィックス (フォルダ相当)。
+  末尾にスラッシュを付ける必要はありません。
+  EOT
+}
+
+variable "schedule_expression" {
+  type        = string
+  description = <<-EOT
+  EventBridge ルールのスケジュール式。
+  例: `cron(0 18 * * ? *)` や `rate(1 day)` など。
+  EOT
+}
+
+variable "task_cpu" {
+  type        = number
+  description = <<-EOT
+  Fargate タスクに割り当てる vCPU 数 (整数)。
+  例: 256 (0.25 vCPU)。
+  EOT
+}
+
+variable "task_memory" {
+  type        = number
+  description = <<-EOT
+  Fargate タスクに割り当てるメモリ量 (MiB)。
+  例: 512。
+  EOT
+}
+


### PR DESCRIPTION
## 概要
- RDS の論理ダンプを定期的に S3 へ保存する `db-dump-to-s3` モジュールを追加
- Secrets Manager から認証情報を取得し、Fargate スケジュールドタスクで `pg_dump` / `mysqldump` を実行
- 利用例 `examples/db-dump-to-s3-minimal` を追加

## テスト
- `terraform fmt modules/db-dump-to-s3/main.tf modules/db-dump-to-s3/variables.tf modules/db-dump-to-s3/outputs.tf examples/db-dump-to-s3-minimal/main.tf`
- `terraform -chdir=examples/db-dump-to-s3-minimal validate` (警告あり)


------
https://chatgpt.com/codex/tasks/task_e_68c1053aae54832e9879aa9d462dfcb8