### PR TITLE
feat: add secrets baseline module

### DIFF
--- a/examples/secrets-baseline-minimal/main.tf
+++ b/examples/secrets-baseline-minimal/main.tf
@@ -1,0 +1,86 @@
+###############################################
+# Example: secrets-baseline (minimal)
+#
+# この例は、2 つの Secrets Manager シークレットを作成する最小構成です。
+# 1) db_password: プレーンテキストのパスワード
+# 2) app_config : ユーザー名/パスワードを含む JSON オブジェクト
+# ローテーションは無効化しています。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# Example inputs
+###############################################
+variable "region" {
+  type        = string
+  description = "デプロイ先リージョン"
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名。タグに使用します。"
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  type        = string
+  description = "環境名（例: dev, stg, prd）。タグに使用します。"
+  default     = "dev"
+}
+
+###############################################
+# Module invocation
+###############################################
+module "secrets_baseline" {
+  source = "../../modules/secrets-baseline"
+
+  name_prefix = "demo"
+  secrets = {
+    db_password = "SuperSecretP@ssw0rd!"
+    app_config = {
+      username = "demo"
+      password = "AnotherSecret!"
+    }
+  }
+
+  enable_rotation = false
+  rotation_days   = 30
+
+  tags = {
+    Project = var.app_name
+    Env     = var.env
+  }
+}
+
+###############################################
+# Helpful output
+###############################################
+output "secret_arns" {
+  value       = module.secrets_baseline.secret_arns
+  description = "作成されたシークレットの ARN マップ"
+}
+

--- a/modules/secrets-baseline/main.tf
+++ b/modules/secrets-baseline/main.tf
@@ -1,0 +1,76 @@
+###############################################
+# Minimal Gov: Secrets Baseline module
+#
+# このモジュールは、AWS Secrets Manager を用いてアプリケーションやデータベースの
+# シークレットを簡易かつ安全に管理するためのベースラインを提供します。
+# 複数のシークレットを一括作成し、必要に応じてローテーション設定を有効化できます。
+#
+# 作成するリソース:
+# - aws_secretsmanager_secret: シークレットのメタデータ
+# - aws_secretsmanager_secret_version: 初期シークレット値
+# - (オプション) aws_secretsmanager_secret_rotation: ローテーション設定
+#
+# 設計指針:
+# - ロジックは可能な限り単純化し、可読性を優先
+# - セキュリティ既定値として暗号化は AWS 管理キーを使用 (追加設定不要)
+# - 出力は上位モジュールが依存する最小限（ARN のみ）
+###############################################
+
+###############################################
+# Locals
+###############################################
+locals {
+  # シークレット名などに付与するプレフィックス。未指定時は "secret"
+  name_prefix = var.name_prefix != null && var.name_prefix != "" ? var.name_prefix : "secret"
+
+  # 入力されたシークレットマップを明示的に tomap し、型のばらつきを許容
+  secrets_map = tomap(var.secrets)
+
+  # シークレットの値を文字列化
+  # - 値が文字列の場合はそのまま利用
+  # - 値がオブジェクト/マップの場合は JSON 文字列へ変換
+  secret_payloads = {
+    for k, v in local.secrets_map :
+    k => (can(regex("", v)) ? v : jsonencode(v))
+  }
+}
+
+###############################################
+# Secrets Manager: Secret definition
+###############################################
+resource "aws_secretsmanager_secret" "this" {
+  for_each = local.secrets_map
+
+  name        = "${local.name_prefix}-${each.key}"
+  description = "Managed secret for ${each.key}"
+
+  tags = merge({
+    Name = "${local.name_prefix}-${each.key}"
+  }, var.tags)
+}
+
+###############################################
+# Secrets Manager: Initial value
+###############################################
+resource "aws_secretsmanager_secret_version" "this" {
+  for_each = aws_secretsmanager_secret.this
+
+  secret_id     = each.value.id
+  secret_string = local.secret_payloads[each.key]
+}
+
+###############################################
+# Secrets Manager: Rotation (optional)
+# enable_rotation が true の場合のみ作成します。
+###############################################
+resource "aws_secretsmanager_secret_rotation" "this" {
+  for_each = var.enable_rotation ? aws_secretsmanager_secret.this : {}
+
+  secret_id           = each.value.id
+  rotation_lambda_arn = var.rotation_lambda_arn
+
+  rotation_rules {
+    automatically_after_days = var.rotation_days
+  }
+}
+

--- a/modules/secrets-baseline/outputs.tf
+++ b/modules/secrets-baseline/outputs.tf
@@ -1,0 +1,15 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみ出力します。
+###############################################
+
+output "secret_arns" {
+  description = <<-EOT
+  作成された Secrets Manager シークレットの ARN マップ。
+  例: module.secrets_baseline.secret_arns["db_password"]
+  EOT
+  value = {
+    for k, v in aws_secretsmanager_secret.this : k => v.arn
+  }
+}
+

--- a/modules/secrets-baseline/variables.tf
+++ b/modules/secrets-baseline/variables.tf
@@ -1,0 +1,85 @@
+###############################################
+# Variables
+# すべての変数に詳細な説明とバリデーションを付与します。
+###############################################
+
+variable "name_prefix" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  作成するシークレット名や Name タグに付与する任意のプレフィックス。
+  未指定（null/空文字）の場合は "secret" を用います。
+
+  例: "app" を指定するとシークレット名は "app-<key>" となります。
+  EOT
+}
+
+variable "secrets" {
+  type        = any
+  description = <<-EOT
+  作成するシークレットの内容を表すマップ。
+  キーがシークレットの論理名、値がシークレットの中身です。
+  値はプレーン文字列またはオブジェクト（JSON 化して保存）を混在させて指定できます。
+
+  例:
+  {
+    db_password = "P@ssw0rd"
+    app_config  = {
+      username = "user"
+      password = "pass"
+    }
+  }
+  EOT
+
+  validation {
+    condition     = can(keys(var.secrets)) && length(keys(var.secrets)) > 0
+    error_message = "secrets は 1 つ以上の要素を持つ map で指定してください。"
+  }
+}
+
+variable "enable_rotation" {
+  type        = bool
+  default     = false
+  description = <<-EOT
+  シークレットのローテーションを有効化するかどうか。
+  true の場合は rotation_lambda_arn を必ず指定してください。
+  EOT
+}
+
+variable "rotation_days" {
+  type        = number
+  default     = 30
+  description = <<-EOT
+  ローテーション間隔（日数）。
+  enable_rotation が true の場合にのみ参照されます。
+  EOT
+
+  validation {
+    condition     = var.rotation_days > 0
+    error_message = "rotation_days は 1 以上の数値を指定してください。"
+  }
+}
+
+variable "rotation_lambda_arn" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  シークレットのローテーションを実行する Lambda 関数の ARN。
+  enable_rotation が true の場合に必須です。それ以外は未指定でも構いません。
+  EOT
+
+  validation {
+    condition     = !var.enable_rotation || (var.rotation_lambda_arn != null && var.rotation_lambda_arn != "")
+    error_message = "enable_rotation が true の場合、rotation_lambda_arn を指定してください。"
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  すべてのリソースに付与する共通タグ。
+  コンプライアンスやコスト配賦のため、Project/Env/Owner 等のタグ付与を推奨します。
+  EOT
+}
+


### PR DESCRIPTION
## Summary
- add reusable secrets baseline module
- provide minimal example for secrets baseline usage

## Testing
- `terraform -chdir=examples/secrets-baseline-minimal init -backend=false`
- `terraform -chdir=examples/secrets-baseline-minimal validate`
- `terraform -chdir=modules/secrets-baseline init -backend=false`
- `terraform -chdir=modules/secrets-baseline validate`


------
https://chatgpt.com/codex/tasks/task_e_68c105554080832eb6d63aa1d5de4e7b