### PR TITLE
ECR リポジトリモジュールを追加

### DIFF
--- a/examples/ecr-repository-minimal/main.tf
+++ b/examples/ecr-repository-minimal/main.tf
@@ -1,0 +1,65 @@
+###############################################
+# Example: ecr-repository (minimal)
+#
+# この例では、本モジュールを用いて最小限の ECR リポジトリを作成します。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+variable "region" {
+  description = "デプロイ先リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  description = "アプリケーション名（タグ用）"
+  type        = string
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  description = "環境名（タグ用）"
+  type        = string
+  default     = "dev"
+}
+
+###############################################
+# ECR Repository Module
+###############################################
+module "ecr" {
+  source = "../../modules/ecr-repository"
+
+  env      = var.env
+  app_name = var.app_name
+  region   = var.region
+  name     = "sample-app"
+}
+
+output "repository_url" {
+  value       = module.ecr.repository_url
+  description = "作成されたリポジトリの URL。docker push/pull 時に利用します。"
+}
+

--- a/modules/ecr-repository/main.tf
+++ b/modules/ecr-repository/main.tf
@@ -1,0 +1,119 @@
+###############################################
+# Minimal Gov: ECR Repository module
+#
+# このモジュールは、アプリケーションのコンテナイメージを保存する
+# セキュアな Amazon ECR プライベートリポジトリを作成します。
+# 主な機能:
+# - プッシュ時のイメージスキャンを既定で有効化 (脆弱性検出)
+# - KMS による暗号化を強制（未指定時は AWS 管理キー）
+# - タグのイミュータビリティを強制 (意図しない上書きを防止)
+# - ライフサイクルポリシーで最新イメージのみ保持
+# - 任意で他アカウントからの pull を許可
+#
+# これにより、最小限の入力でガバナンスに沿った ECR リポジトリを
+# 即座に利用できます。
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+###############################################
+# ECR Repository
+# - セキュアな既定値をフルで有効化
+###############################################
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = "IMMUTABLE" # タグ上書きを防止
+
+  # プッシュ時にイメージスキャンを実施
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  # KMS で暗号化 (キー未指定なら AWS 管理キー)
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = var.kms_key_arn
+  }
+
+  tags = merge(
+    { Name = var.name },
+    var.tags,
+  )
+}
+
+###############################################
+# Lifecycle Policy
+# - 過去のイメージを自動削除し、最新のみ保持
+###############################################
+resource "aws_ecr_lifecycle_policy" "this" {
+  repository = aws_ecr_repository.this.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Retain last ${var.keep_last_images} images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.keep_last_images
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}
+
+###############################################
+# Cross-account Pull Policy (optional)
+# - pull_principal_arns に渡された IAM Principal に pull を許可
+###############################################
+data "aws_iam_policy_document" "cross_account" {
+  count = length(var.pull_principal_arns) > 0 ? 1 : 0
+
+  statement {
+    sid = "AllowCrossAccountPull"
+    principals {
+      type        = "AWS"
+      identifiers = var.pull_principal_arns
+    }
+
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:DescribeImages",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+  }
+}
+
+resource "aws_ecr_repository_policy" "cross_account" {
+  count      = length(var.pull_principal_arns) > 0 ? 1 : 0
+  repository = aws_ecr_repository.this.name
+  policy     = data.aws_iam_policy_document.cross_account[0].json
+}
+

--- a/modules/ecr-repository/outputs.tf
+++ b/modules/ecr-repository/outputs.tf
@@ -1,0 +1,22 @@
+###############################################
+# Outputs
+# 上位モジュールから依存に必要な最小限の値のみ出力します。
+# 利用方法のヒントをコメントとして併記します。
+###############################################
+
+output "repository_url" {
+  description = <<-EOT
+  作成された ECR リポジトリのプッシュ/プル用 URL。
+  例: Docker イメージを push する際に "<repository_url>:latest" のように参照します。
+  EOT
+  value       = aws_ecr_repository.this.repository_url
+}
+
+output "repository_arn" {
+  description = <<-EOT
+  ECR リポジトリの ARN。
+  例: IAM ポリシーでリソース指定する際に利用します。
+  EOT
+  value       = aws_ecr_repository.this.arn
+}
+

--- a/modules/ecr-repository/variables.tf
+++ b/modules/ecr-repository/variables.tf
@@ -1,0 +1,65 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "env" {
+  type        = string
+  description = "デプロイ対象の環境名 (例: dev, prod)。provider の default_tags に反映されます。"
+}
+
+variable "app_name" {
+  type        = string
+  description = "アプリケーション名。タグ Application に利用されます。"
+}
+
+variable "region" {
+  type        = string
+  description = "AWS リージョン。provider の region に利用します。"
+}
+
+variable "name" {
+  type        = string
+  description = <<-EOT
+  作成する ECR リポジトリ名。
+  例: "app" を指定すると "app" というリポジトリが作成されます。
+  EOT
+}
+
+variable "keep_last_images" {
+  type        = number
+  default     = 10
+  description = <<-EOT
+  ライフサイクルポリシーで保持する最新イメージ数。
+  指定した数を超える古いイメージは自動削除されます。
+  EOT
+}
+
+variable "kms_key_arn" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  ECR リポジトリの暗号化に使用する KMS キーの ARN。
+  未指定の場合は AWS 管理キー (alias/aws/ecr) が自動的に利用されます。
+  EOT
+}
+
+variable "pull_principal_arns" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+  このリポジトリからイメージを pull できる IAM プリンシパルの ARN 一覧。
+  複数アカウントからの利用を想定する場合に指定してください。
+  空のままにするとクロスアカウントアクセスは付与されません。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  追加で付与する任意のタグ。
+  provider で設定される default_tags に加えてマージされます。
+  EOT
+}
+


### PR DESCRIPTION
## 概要
- ECR リポジトリを作成する Terraform モジュールを新規追加
- 最小構成の利用例を追加

## テスト
- `terraform fmt -recursive modules/ecr-repository examples/ecr-repository-minimal`
- `terraform -chdir=examples/ecr-repository-minimal init -backend=false`
- `terraform -chdir=examples/ecr-repository-minimal validate`


------
https://chatgpt.com/codex/tasks/task_e_68c10582aa54832e913df24d5255397e