### PR TITLE
feat: Transfer Family モジュールを追加

### DIFF
--- a/examples/transfer-family-minimal/main.tf
+++ b/examples/transfer-family-minimal/main.tf
@@ -1,0 +1,79 @@
+###############################################
+# Example: transfer-family (minimal)
+#
+# この例は、本モジュールを最小限の設定で利用する方法を示します。
+# - 追加の VPC やリソースは不要（PUBLIC エンドポイント）
+# - 指定した SSH 公開鍵で接続可能な SFTP サーバとユーザを作成
+###############################################
+
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}
+
+variable "region" {
+  description = "デプロイ先リージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "app_name" {
+  description = "アプリケーション名（タグ用）"
+  type        = string
+  default     = "minimal-gov"
+}
+
+variable "env" {
+  description = "環境名（タグ用）"
+  type        = string
+  default     = "dev"
+}
+
+variable "ssh_public_key" {
+  description = "SFTP ユーザに紐付ける SSH 公開鍵"
+  type        = string
+  default     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCtesmVv08hQ9GzleMFIAk7FFYNO0ilhevia9RNqBm3ELZ1pcU6ZAq/IlBg9qr8zt0sK++VMmgmptvaqYVHkqhNFFexrD68VWW4umk/YnMRzSIvmzzk6Vq8HYPI8RVQG0n3/qEOilXwVA4lb3ksKmEqPwa2DDeqOJCcfoCiM4xNh4GDv5mFLY85U7jti0iUwc3m1/Fc1tN/b5eIV6JqiFMFrFGCxd3bSlkZEYaHB2IIuMkeP5LbVhxWMdKMNs3SkckUa7UB6qruMDoOI9r/s3XFa53mq12drntZvSY4hTIhGpHtIhmZ3r3ENE3j1VFvABmRlMlypF0xLSx9LtyDXcP root@030f361ddfa8"
+}
+
+###############################################
+# Transfer Family Module
+###############################################
+module "transfer" {
+  source         = "../../modules/transfer-family"
+  user_name      = "demo"
+  ssh_public_key = var.ssh_public_key
+
+  tags = {
+    Project = "minimal-gov"
+    Env     = "dev"
+  }
+}
+
+output "server_endpoint" {
+  value       = module.transfer.server_endpoint
+  description = "SFTP 接続に利用するエンドポイント"
+}
+
+output "bucket_name" {
+  value       = module.transfer.bucket_name
+  description = "ファイル格納用 S3 バケット名"
+}

--- a/modules/transfer-family/main.tf
+++ b/modules/transfer-family/main.tf
@@ -1,0 +1,169 @@
+###############################################
+# Minimal Gov: Transfer Family module
+#
+# このモジュールは、AWS Transfer Family SFTP サーバーと
+# セキュアな S3 バケット、単一のサービス管理ユーザを
+# 最小構成で提供します。
+#
+# - S3 バケットは暗号化とパブリックアクセスブロックを既定で有効化
+# - CloudWatch Logs へ接続ログを出力
+# - 指定した SSH 公開鍵で SFTP 接続可能なユーザを1つ作成
+# - 複雑な設定を排し、読みやすさとセキュリティ既定値を重視
+###############################################
+
+###############################################
+# Locals
+###############################################
+locals {
+  # name_prefix は未指定なら "transfer" を利用
+  name_prefix = var.name_prefix != null && var.name_prefix != "" ? var.name_prefix : "transfer"
+}
+
+###############################################
+# S3 Bucket
+# - SFTP ユーザのホームディレクトリとして利用
+# - 暗号化とパブリックアクセスブロックをデフォルトで有効化
+###############################################
+resource "aws_s3_bucket" "this" {
+  bucket = "${local.name_prefix}-bucket"
+
+  tags = merge({
+    Name = "${local.name_prefix}-bucket"
+  }, var.tags)
+}
+
+# パブリックアクセスの完全遮断
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# 既定 KMS によるサーバーサイド暗号化
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+###############################################
+# IAM ロール: CloudWatch Logs 出力用
+###############################################
+data "aws_iam_policy_document" "logging" {
+  statement {
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["arn:aws:logs:*:*:log-group:/aws/transfer/${local.name_prefix}*"]
+  }
+}
+
+resource "aws_iam_role" "logging" {
+  name = "${local.name_prefix}-logging-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "transfer.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  inline_policy {
+    name   = "logging"
+    policy = data.aws_iam_policy_document.logging.json
+  }
+
+  tags = merge({
+    Name = "${local.name_prefix}-logging-role"
+  }, var.tags)
+}
+
+###############################################
+# IAM ロール: ユーザ用 S3 アクセス
+# - transfer.amazonaws.com が引き受ける想定
+###############################################
+data "aws_iam_policy_document" "user_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["transfer.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "user_access" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.this.arn]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
+  }
+}
+
+resource "aws_iam_role" "user" {
+  name               = "${local.name_prefix}-user-role"
+  assume_role_policy = data.aws_iam_policy_document.user_assume.json
+
+  inline_policy {
+    name   = "s3-access"
+    policy = data.aws_iam_policy_document.user_access.json
+  }
+
+  tags = merge({
+    Name = "${local.name_prefix}-user-role"
+  }, var.tags)
+}
+
+###############################################
+# Transfer Family Server
+###############################################
+resource "aws_transfer_server" "this" {
+  identity_provider_type = "SERVICE_MANAGED"
+  logging_role           = aws_iam_role.logging.arn
+  protocols              = var.protocols
+  endpoint_type          = var.endpoint_type
+
+  tags = merge({
+    Name = "${local.name_prefix}-server"
+  }, var.tags)
+}
+
+###############################################
+# Transfer Family User
+###############################################
+resource "aws_transfer_user" "this" {
+  server_id = aws_transfer_server.this.id
+  user_name = var.user_name
+  role      = aws_iam_role.user.arn
+
+  # S3 バケット直下をホームディレクトリとして指定
+  home_directory = "/${aws_s3_bucket.this.id}"
+
+  tags = merge({
+    Name = "${local.name_prefix}-${var.user_name}"
+  }, var.tags)
+}
+
+# ユーザに SSH 公開鍵を関連付け
+resource "aws_transfer_ssh_key" "this" {
+  server_id = aws_transfer_server.this.id
+  user_name = aws_transfer_user.this.user_name
+  body      = var.ssh_public_key
+}

--- a/modules/transfer-family/outputs.tf
+++ b/modules/transfer-family/outputs.tf
@@ -1,0 +1,19 @@
+###############################################
+# Outputs
+# 利用者が依存に必要な最小限の情報のみを公開します。
+###############################################
+
+output "server_id" {
+  value       = aws_transfer_server.this.id
+  description = "作成された Transfer Family サーバの ID。ユーザ追加などで参照します。"
+}
+
+output "server_endpoint" {
+  value       = aws_transfer_server.this.endpoint
+  description = "SFTP クライアントが接続するエンドポイント URL。"
+}
+
+output "bucket_name" {
+  value       = aws_s3_bucket.this.id
+  description = "SFTP データを格納する S3 バケット名。外部連携などで利用します。"
+}

--- a/modules/transfer-family/variables.tf
+++ b/modules/transfer-family/variables.tf
@@ -1,0 +1,58 @@
+###############################################
+# Variables
+# すべての変数に詳細説明を付与します。
+###############################################
+
+variable "name_prefix" {
+  type        = string
+  default     = null
+  description = <<-EOT
+  リソース名や Name タグに付与する任意のプレフィックス。
+  未指定（null/空文字）の場合は "transfer" を使用します。
+  EOT
+}
+
+variable "user_name" {
+  type        = string
+  description = <<-EOT
+  SFTP 接続に使用するユーザ名。
+  このモジュールでは 1 ユーザのみを作成します。
+  EOT
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = <<-EOT
+  上記ユーザに紐付ける SSH 公開鍵。
+  一般的な "ssh-rsa" や "ssh-ed25519" 形式で指定してください。
+  EOT
+}
+
+variable "protocols" {
+  type        = list(string)
+  default     = ["SFTP"]
+  description = <<-EOT
+  Transfer Family サーバで有効化するプロトコルの一覧。
+  既定では SFTP のみを有効にします。
+  例: ["SFTP", "FTPS"]
+  EOT
+}
+
+variable "endpoint_type" {
+  type        = string
+  default     = "PUBLIC"
+  description = <<-EOT
+  サーバのエンドポイント種別。
+  "PUBLIC"（インターネット公開）または "VPC" を指定できます。
+  最小構成では PUBLIC を既定とします。
+  EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+  すべてのリソースに付与する共通タグ。
+  例: { Project = "minimal-gov", Env = "dev" }
+  EOT
+}


### PR DESCRIPTION
## 概要
- AWS Transfer Family サーバーと S3 バケットを構築する最小モジュールを追加
- 公開鍵で接続可能なユーザと CloudWatch Logs 連携を実装
- 最小利用例を examples/transfer-family-minimal として追加

## テスト
- `terraform fmt modules/transfer-family/main.tf modules/transfer-family/variables.tf modules/transfer-family/outputs.tf examples/transfer-family-minimal/main.tf`
- `(cd examples/transfer-family-minimal && terraform init -backend=false && terraform validate)`


------
https://chatgpt.com/codex/tasks/task_e_68c107876f34832eb6189152a74c7185