### PR TITLE
Add network root module for live environment

### DIFF
--- a/infra/live/network/ap-northeast-1/network/.terraform.lock.hcl
+++ b/infra/live/network/ap-northeast-1/network/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.12.0"
+  constraints = "~> 6.9"
+  hashes = [
+    "h1:8u90EMle+I3Auh4f/LPP6fEfRsAF6xCFnUZF4b7ngEs=",
+    "zh:054bcbf13c6ac9ddd2247876f82f9b56493e2f71d8c88baeec142386a395165d",
+    "zh:195489f16ad5621db2cec80be997d33060462a3b8d442c890bef3eceba34fa4d",
+    "zh:3461ef14904ab7de246296e44d24c042f3190e6bead3d7ce1d9fda63dcb0f047",
+    "zh:44517a0035996431e4127f45db5a84f53ce80730eae35629eda3101709df1e5c",
+    "zh:4b0374abaa6b9a9debed563380cc944873e4f30771dd1da7b9e812a49bf485e3",
+    "zh:531468b99465bd98a89a4ce2f1a30168dfadf6edb57f7836df8a977a2c4f9804",
+    "zh:6a95ed7b4852174aa748d3412bff3d45e4d7420d12659f981c3d9f4a1a59a35f",
+    "zh:88c2d21af1e64eed4a13dbb85590c66a519f3ecc54b72875d4bb6326f3ef84e7",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a8b648470bb5df098e56b1ec5c6a39e0bbb7b496b23a19ea9f494bf48d4a122a",
+    "zh:b23fb13efdb527677db546bc92aeb2bdf64ff3f480188841f2bfdfa7d3d907c1",
+    "zh:be5858a1951ae5f5a9c388949c3e3c66a3375f684fb79b06b1d1db7a9703b18e",
+    "zh:c368e03a7c922493daf4c7348faafc45f455225815ef218b5491c46cea5f76b7",
+    "zh:e31e75d5d19b8ac08aa01be7e78207966e1faa3b82ed9fe3acfdc2d806be924c",
+    "zh:ea84182343b5fd9252a6fae41e844eed4fdc3311473a753b09f06e49ec0e7853",
+  ]
+}

--- a/infra/live/network/ap-northeast-1/network/backend.tf
+++ b/infra/live/network/ap-northeast-1/network/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-network-backend-tfstate-ap-northeast-1-653502182074"
+    key          = "state/network/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/network/ap-northeast-1/network/main.tf
+++ b/infra/live/network/ap-northeast-1/network/main.tf
@@ -1,0 +1,48 @@
+module "network_vpc" {
+  source                      = "../../../../modules/vpc-spoke"
+  name_prefix                 = "network"
+  vpc_cidr                    = var.vpc_cidr
+  azs                         = var.azs
+  private_subnet_count_per_az = var.private_subnet_count_per_az
+  subnet_newbits              = var.subnet_newbits
+  tags                        = var.tags
+}
+
+module "tgw" {
+  source                          = "../../../../modules/tgw-hub"
+  description                     = var.tgw_description
+  amazon_side_asn                 = var.tgw_amazon_side_asn
+  auto_accept_shared_attachments  = "disable"
+  default_route_table_association = "disable"
+  default_route_table_propagation = "disable"
+  dns_support                     = "enable"
+  vpn_ecmp_support                = "enable"
+  tags                            = var.tags
+}
+
+module "tgw_attachment" {
+  source                                          = "../../../../modules/tgw-vpc-attachment"
+  transit_gateway_id                              = module.tgw.tgw_id
+  vpc_id                                          = module.network_vpc.vpc_id
+  subnet_ids                                      = [for az in var.azs : module.network_vpc.private_subnet_ids_by_az[az][0]]
+  dns_support                                     = "enable"
+  ipv6_support                                    = "disable"
+  appliance_mode_support                          = "disable"
+  transit_gateway_default_route_table_association = "disable"
+  transit_gateway_default_route_table_propagation = "disable"
+  tags                                            = var.tags
+}
+
+module "vpc_endpoints" {
+  source                     = "../../../../modules/vpc-endpoints-baseline"
+  vpc_id                     = module.network_vpc.vpc_id
+  subnet_ids                 = [for az in var.azs : module.network_vpc.private_subnet_ids_by_az[az][0]]
+  route_table_ids            = module.network_vpc.route_table_ids
+  allowed_cidrs              = var.vpce_allowed_cidrs
+  interface_endpoints        = var.interface_endpoints
+  gateway_endpoints          = var.gateway_endpoints
+  enable_interface_endpoints = true
+  enable_gateway_endpoints   = true
+  enable_private_dns         = true
+  tags                       = var.tags
+}

--- a/infra/live/network/ap-northeast-1/network/outputs.tf
+++ b/infra/live/network/ap-northeast-1/network/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the network VPC"
+  value       = module.network_vpc.vpc_id
+}
+
+output "tgw_id" {
+  description = "ID of the Transit Gateway"
+  value       = module.tgw.tgw_id
+}
+
+output "tgw_vpc_attachment_id" {
+  description = "ID of the TGW VPC attachment"
+  value       = module.tgw_attachment.attachment_id
+}

--- a/infra/live/network/ap-northeast-1/network/provider.tf
+++ b/infra/live/network/ap-northeast-1/network/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "network"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/network/ap-northeast-1/network/terraform.tfvars
+++ b/infra/live/network/ap-northeast-1/network/terraform.tfvars
@@ -1,0 +1,25 @@
+env      = "prod"
+app_name = "minimal-gov-network"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+vpc_cidr                    = "10.10.0.0/16"
+azs                         = ["ap-northeast-1a", "ap-northeast-1c"]
+private_subnet_count_per_az = 2
+subnet_newbits              = 4
+
+tgw_amazon_side_asn = 64512
+tgw_description     = "Minimal Gov Transit Gateway"
+
+vpce_allowed_cidrs = ["10.10.0.0/16"]
+interface_endpoints = [
+  "ssm",
+  "ssmmessages",
+  "ec2messages",
+  "kms",
+  "logs"
+]
+gateway_endpoints = ["s3"]

--- a/infra/live/network/ap-northeast-1/network/variable.tf
+++ b/infra/live/network/ap-northeast-1/network/variable.tf
@@ -1,0 +1,75 @@
+variable "env" {
+  description = "Deployment environment"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name used for tagging"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}
+
+# VPC settings
+variable "vpc_cidr" {
+  description = "CIDR block for the network VPC"
+  type        = string
+}
+
+variable "azs" {
+  description = "List of availability zones"
+  type        = list(string)
+}
+
+variable "private_subnet_count_per_az" {
+  description = "Number of private subnets to create per AZ"
+  type        = number
+  default     = 2
+}
+
+variable "subnet_newbits" {
+  description = "Newbits for subnet CIDR calculation"
+  type        = number
+  default     = 4
+}
+
+# Transit Gateway settings
+variable "tgw_amazon_side_asn" {
+  description = "Amazon side ASN for the Transit Gateway"
+  type        = number
+  default     = 64512
+}
+
+variable "tgw_description" {
+  description = "Description for the Transit Gateway"
+  type        = string
+  default     = "Minimal Gov Transit Gateway"
+}
+
+# VPC Endpoints settings
+variable "vpce_allowed_cidrs" {
+  description = "CIDR blocks allowed to access interface endpoints"
+  type        = list(string)
+  default     = []
+}
+
+variable "interface_endpoints" {
+  description = "Interface endpoint services to create"
+  type        = list(string)
+  default     = []
+}
+
+variable "gateway_endpoints" {
+  description = "Gateway endpoint services to create"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary
- add Terraform root module for live network account
- provision VPC, Transit Gateway hub, attachment and baseline VPC endpoints

## Testing
- `terraform -chdir=infra/live/network/ap-northeast-1/network fmt`
- `terraform -chdir=infra/live/network/ap-northeast-1/network init -backend=false`
- `terraform -chdir=infra/live/network/ap-northeast-1/network validate`


------
https://chatgpt.com/codex/tasks/task_e_68c1371c27d0832e9488a9dcf8240498