### PR TITLE
Add on-prem simulation root module

### DIFF
--- a/infra/live/onprem/ap-northeast-1/onprem-sim/backend.tf
+++ b/infra/live/onprem/ap-northeast-1/onprem-sim/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-onprem-backend-tfstate-ap-northeast-1-653502182074"
+    key          = "state/onprem/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/onprem/ap-northeast-1/onprem-sim/main.tf
+++ b/infra/live/onprem/ap-northeast-1/onprem-sim/main.tf
@@ -1,0 +1,11 @@
+module "onprem_sim" {
+  source = "../../../../modules/onprem-sim"
+
+  vpc_cidr           = var.vpc_cidr
+  public_subnet_cidr = var.public_subnet_cidr
+  az                 = var.az
+  instance_type      = var.instance_type
+  ami_id             = var.ami_id
+  name_prefix        = var.name_prefix
+  tags               = var.tags
+}

--- a/infra/live/onprem/ap-northeast-1/onprem-sim/outputs.tf
+++ b/infra/live/onprem/ap-northeast-1/onprem-sim/outputs.tf
@@ -1,0 +1,19 @@
+output "vpc_id" {
+  description = "ID of the simulated on-prem VPC"
+  value       = module.onprem_sim.vpc_id
+}
+
+output "subnet_id" {
+  description = "ID of the public subnet hosting the strongSwan instance"
+  value       = module.onprem_sim.subnet_id
+}
+
+output "instance_id" {
+  description = "ID of the strongSwan EC2 instance"
+  value       = module.onprem_sim.instance_id
+}
+
+output "eip" {
+  description = "Elastic IP assigned to the strongSwan instance"
+  value       = module.onprem_sim.eip
+}

--- a/infra/live/onprem/ap-northeast-1/onprem-sim/provider.tf
+++ b/infra/live/onprem/ap-northeast-1/onprem-sim/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "onprem"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/onprem/ap-northeast-1/onprem-sim/terraform.tfvars
+++ b/infra/live/onprem/ap-northeast-1/onprem-sim/terraform.tfvars
@@ -1,0 +1,13 @@
+env      = "onprem"
+app_name = "minimal-gov-onprem"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+vpc_cidr           = "10.255.0.0/16"
+public_subnet_cidr = "10.255.0.0/24"
+az                 = "ap-northeast-1a"
+instance_type      = "t3.small"
+name_prefix        = "onprem"

--- a/infra/live/onprem/ap-northeast-1/onprem-sim/variable.tf
+++ b/infra/live/onprem/ap-northeast-1/onprem-sim/variable.tf
@@ -1,0 +1,53 @@
+variable "env" {
+  description = "Deployment environment"
+  type        = string
+}
+
+variable "app_name" {
+  description = "Application name used for tagging"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the simulated on-prem VPC"
+  type        = string
+}
+
+variable "public_subnet_cidr" {
+  description = "CIDR block for the public subnet hosting the strongSwan instance"
+  type        = string
+}
+
+variable "az" {
+  description = "Availability zone for the public subnet"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the strongSwan gateway"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "ami_id" {
+  description = "AMI ID for the strongSwan instance"
+  type        = string
+  default     = null
+}
+
+variable "name_prefix" {
+  description = "Prefix used for naming resources"
+  type        = string
+  default     = "onprem"
+}


### PR DESCRIPTION
## Summary
- add Terraform root module to provision AWS-based on-prem simulation
- configure remote backend, provider, and outputs

## Testing
- `terraform fmt -recursive infra/live/onprem/ap-northeast-1/onprem-sim`
- `cd infra/live/onprem/ap-northeast-1/onprem-sim && terraform init -backend=false`
- `cd infra/live/onprem/ap-northeast-1/onprem-sim && terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68c36787c2c8832e9029bbb8c0e92da3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an on‑prem simulation environment in ap-northeast-1 with configurable VPC, subnet, AZ, AMI, and instance settings.
  - Exposes outputs for VPC ID, subnet ID, instance ID, and Elastic IP to simplify integration.

- Chores
  - Established remote state backend with encryption and state locking.
  - Defined provider and version requirements with standardized default tags.
  - Added environment variables and defaults to streamline configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->