### PR TITLE
feat(security): add core security root modules

### DIFF
--- a/infra/live/security/ap-northeast-1/cloudtrail/backend.tf
+++ b/infra/live/security/ap-northeast-1/cloudtrail/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-sec-backend-tfstate-ap-northeast-1-454842420215"
+    key          = "state/cloudtrail/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/security/ap-northeast-1/cloudtrail/main.tf
+++ b/infra/live/security/ap-northeast-1/cloudtrail/main.tf
@@ -1,0 +1,10 @@
+module "cloudtrail" {
+  source         = "../../../../modules/security-cloudtrail"
+  trail_name     = var.trail_name
+  bucket_name    = var.bucket_name
+  region         = var.region
+  use_kms        = var.use_kms
+  kms_key_id     = var.kms_key_id
+  enable_logging = var.enable_logging
+  tags           = var.tags
+}

--- a/infra/live/security/ap-northeast-1/cloudtrail/outputs.tf
+++ b/infra/live/security/ap-northeast-1/cloudtrail/outputs.tf
@@ -1,0 +1,9 @@
+output "trail_arn" {
+  description = "ARN of the CloudTrail trail"
+  value       = module.cloudtrail.trail_arn
+}
+
+output "bucket_name" {
+  description = "S3 bucket name for CloudTrail logs"
+  value       = module.cloudtrail.bucket_name
+}

--- a/infra/live/security/ap-northeast-1/cloudtrail/provider.tf
+++ b/infra/live/security/ap-northeast-1/cloudtrail/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "security"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/security/ap-northeast-1/cloudtrail/terraform.tfvars
+++ b/infra/live/security/ap-northeast-1/cloudtrail/terraform.tfvars
@@ -1,0 +1,16 @@
+# === 必須系 ===
+env      = "prod"
+app_name = "minimal-gov-cloudtrail"
+region   = "ap-northeast-1"
+
+# === 任意タグ ===
+tags = {
+  Project = "minimal-gov"
+}
+
+# === CloudTrail 設定 ===
+trail_name     = "org-trail"
+bucket_name    = null
+use_kms        = false
+kms_key_id     = null
+enable_logging = true

--- a/infra/live/security/ap-northeast-1/cloudtrail/variable.tf
+++ b/infra/live/security/ap-northeast-1/cloudtrail/variable.tf
@@ -1,0 +1,58 @@
+variable "env" {
+  type = string
+  validation {
+    condition     = can(regex("^(dev|stg|prod|sandbox)$", var.env))
+    error_message = "env は dev|stg|prod|sandbox のいずれか。"
+  }
+}
+
+variable "app_name" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]{3,32}$", var.app_name))
+    error_message = "app_name は 3–32 文字の英数/ハイフン/アンダースコア。"
+  }
+}
+
+variable "region" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-\\d$", var.region))
+    error_message = "region の形式が不正。例: ap-northeast-1"
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to merge on top of provider default_tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "trail_name" {
+  description = "Name of the CloudTrail trail"
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "S3 bucket to store CloudTrail logs"
+  type        = string
+  default     = null
+}
+
+variable "use_kms" {
+  description = "Encrypt logs with a KMS key"
+  type        = bool
+  default     = false
+}
+
+variable "kms_key_id" {
+  description = "KMS key ID when use_kms is true"
+  type        = string
+  default     = null
+}
+
+variable "enable_logging" {
+  description = "Start logging immediately"
+  type        = bool
+  default     = true
+}

--- a/infra/live/security/ap-northeast-1/config/backend.tf
+++ b/infra/live/security/ap-northeast-1/config/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-sec-backend-tfstate-ap-northeast-1-454842420215"
+    key          = "state/config/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/security/ap-northeast-1/config/main.tf
+++ b/infra/live/security/ap-northeast-1/config/main.tf
@@ -1,0 +1,11 @@
+module "config" {
+  source                      = "../../../../modules/security-config"
+  env                         = var.env
+  app_name                    = var.app_name
+  region                      = var.region
+  bucket_name                 = var.bucket_name
+  create_bucket               = var.create_bucket
+  aggregator_role_name        = var.aggregator_role_name
+  snapshot_delivery_frequency = var.snapshot_delivery_frequency
+  tags                        = var.tags
+}

--- a/infra/live/security/ap-northeast-1/config/outputs.tf
+++ b/infra/live/security/ap-northeast-1/config/outputs.tf
@@ -1,0 +1,14 @@
+output "recorder_name" {
+  value       = module.config.recorder_name
+  description = "Name of the AWS Config recorder"
+}
+
+output "delivery_channel_name" {
+  value       = module.config.delivery_channel_name
+  description = "Name of the AWS Config delivery channel"
+}
+
+output "aggregator_arn" {
+  value       = module.config.aggregator_arn
+  description = "ARN of the organization Config aggregator"
+}

--- a/infra/live/security/ap-northeast-1/config/provider.tf
+++ b/infra/live/security/ap-northeast-1/config/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "security"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/security/ap-northeast-1/config/terraform.tfvars
+++ b/infra/live/security/ap-northeast-1/config/terraform.tfvars
@@ -1,0 +1,15 @@
+# === 必須系 ===
+env      = "prod"
+app_name = "minimal-gov-config"
+region   = "ap-northeast-1"
+
+# === 任意タグ ===
+tags = {
+  Project = "minimal-gov"
+}
+
+# === Config 設定 ===
+bucket_name                 = "minimal-gov-config"
+create_bucket               = true
+aggregator_role_name        = "AWSConfigAggregatorRole"
+snapshot_delivery_frequency = "TwentyFour_Hours"

--- a/infra/live/security/ap-northeast-1/config/variable.tf
+++ b/infra/live/security/ap-northeast-1/config/variable.tf
@@ -1,0 +1,52 @@
+variable "env" {
+  type = string
+  validation {
+    condition     = can(regex("^(dev|stg|prod|sandbox)$", var.env))
+    error_message = "env は dev|stg|prod|sandbox のいずれか。"
+  }
+}
+
+variable "app_name" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]{3,32}$", var.app_name))
+    error_message = "app_name は 3–32 文字の英数/ハイフン/アンダースコア。"
+  }
+}
+
+variable "region" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-\\d$", var.region))
+    error_message = "region の形式が不正。例: ap-northeast-1"
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to merge on top of provider default_tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "bucket_name" {
+  description = "S3 bucket name for Config snapshots"
+  type        = string
+}
+
+variable "create_bucket" {
+  description = "Whether to create the S3 bucket"
+  type        = bool
+  default     = true
+}
+
+variable "aggregator_role_name" {
+  description = "IAM role name for the Config aggregator"
+  type        = string
+  default     = "AWSConfigAggregatorRole"
+}
+
+variable "snapshot_delivery_frequency" {
+  description = "Frequency for Config snapshot delivery"
+  type        = string
+  default     = "TwentyFour_Hours"
+}

--- a/infra/live/security/ap-northeast-1/guardduty/backend.tf
+++ b/infra/live/security/ap-northeast-1/guardduty/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-sec-backend-tfstate-ap-northeast-1-454842420215"
+    key          = "state/guardduty/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/security/ap-northeast-1/guardduty/main.tf
+++ b/infra/live/security/ap-northeast-1/guardduty/main.tf
@@ -1,0 +1,6 @@
+module "guardduty" {
+  source              = "../../../../modules/security-guardduty"
+  name_prefix         = var.name_prefix
+  auto_enable_members = var.auto_enable_members
+  tags                = var.tags
+}

--- a/infra/live/security/ap-northeast-1/guardduty/outputs.tf
+++ b/infra/live/security/ap-northeast-1/guardduty/outputs.tf
@@ -1,0 +1,4 @@
+output "detector_id" {
+  description = "ID of the GuardDuty detector"
+  value       = module.guardduty.detector_id
+}

--- a/infra/live/security/ap-northeast-1/guardduty/provider.tf
+++ b/infra/live/security/ap-northeast-1/guardduty/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "security"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/security/ap-northeast-1/guardduty/terraform.tfvars
+++ b/infra/live/security/ap-northeast-1/guardduty/terraform.tfvars
@@ -1,0 +1,13 @@
+# === 必須系 ===
+env      = "prod"
+app_name = "minimal-gov-guardduty"
+region   = "ap-northeast-1"
+
+# === 任意タグ ===
+tags = {
+  Project = "minimal-gov"
+}
+
+# === GuardDuty 設定 ===
+name_prefix         = "security"
+auto_enable_members = "ALL"

--- a/infra/live/security/ap-northeast-1/guardduty/variable.tf
+++ b/infra/live/security/ap-northeast-1/guardduty/variable.tf
@@ -1,0 +1,41 @@
+variable "env" {
+  type = string
+  validation {
+    condition     = can(regex("^(dev|stg|prod|sandbox)$", var.env))
+    error_message = "env は dev|stg|prod|sandbox のいずれか。"
+  }
+}
+
+variable "app_name" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]{3,32}$", var.app_name))
+    error_message = "app_name は 3–32 文字の英数/ハイフン/アンダースコア。"
+  }
+}
+
+variable "region" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-\\d$", var.region))
+    error_message = "region の形式が不正。例: ap-northeast-1"
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to merge on top of provider default_tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+  default     = null
+}
+
+variable "auto_enable_members" {
+  description = "How to auto-enable organization accounts"
+  type        = string
+  default     = "ALL"
+}

--- a/infra/live/security/ap-northeast-1/securityhub/backend.tf
+++ b/infra/live/security/ap-northeast-1/securityhub/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-sec-backend-tfstate-ap-northeast-1-454842420215"
+    key          = "state/securityhub/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/security/ap-northeast-1/securityhub/main.tf
+++ b/infra/live/security/ap-northeast-1/securityhub/main.tf
@@ -1,0 +1,6 @@
+module "securityhub" {
+  source              = "../../../../modules/security-securityhub"
+  auto_enable_members = var.auto_enable_members
+  enable_afsbp        = var.enable_afsbp
+  linking_mode        = var.linking_mode
+}

--- a/infra/live/security/ap-northeast-1/securityhub/outputs.tf
+++ b/infra/live/security/ap-northeast-1/securityhub/outputs.tf
@@ -1,0 +1,4 @@
+output "finding_aggregator_arn" {
+  description = "ARN of the Security Hub finding aggregator"
+  value       = module.securityhub.finding_aggregator_arn
+}

--- a/infra/live/security/ap-northeast-1/securityhub/provider.tf
+++ b/infra/live/security/ap-northeast-1/securityhub/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "security"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/security/ap-northeast-1/securityhub/terraform.tfvars
+++ b/infra/live/security/ap-northeast-1/securityhub/terraform.tfvars
@@ -1,0 +1,14 @@
+# === 必須系 ===
+env      = "prod"
+app_name = "minimal-gov-securityhub"
+region   = "ap-northeast-1"
+
+# === 任意タグ ===
+tags = {
+  Project = "minimal-gov"
+}
+
+# === Security Hub 設定 ===
+auto_enable_members = true
+enable_afsbp        = true
+linking_mode        = "ALL_REGIONS"

--- a/infra/live/security/ap-northeast-1/securityhub/variable.tf
+++ b/infra/live/security/ap-northeast-1/securityhub/variable.tf
@@ -1,0 +1,47 @@
+variable "env" {
+  type = string
+  validation {
+    condition     = can(regex("^(dev|stg|prod|sandbox)$", var.env))
+    error_message = "env は dev|stg|prod|sandbox のいずれか。"
+  }
+}
+
+variable "app_name" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]{3,32}$", var.app_name))
+    error_message = "app_name は 3–32 文字の英数/ハイフン/アンダースコア。"
+  }
+}
+
+variable "region" {
+  type = string
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-\\d$", var.region))
+    error_message = "region の形式が不正。例: ap-northeast-1"
+  }
+}
+
+variable "tags" {
+  description = "Additional tags to merge on top of provider default_tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "auto_enable_members" {
+  description = "Automatically enable member accounts"
+  type        = bool
+  default     = true
+}
+
+variable "enable_afsbp" {
+  description = "Subscribe to AWS Foundational Security Best Practices"
+  type        = bool
+  default     = true
+}
+
+variable "linking_mode" {
+  description = "Finding aggregation mode"
+  type        = string
+  default     = "ALL_REGIONS"
+}


### PR DESCRIPTION
## Summary
- add CloudTrail root module for centralized audit logging
- configure AWS Config, GuardDuty, and Security Hub root modules in security account

## Testing
- `terraform fmt -recursive infra/live/security/ap-northeast-1/cloudtrail infra/live/security/ap-northeast-1/config infra/live/security/ap-northeast-1/guardduty infra/live/security/ap-northeast-1/securityhub`
- `terraform init -backend=false` & `terraform validate` (cloudtrail)
- `terraform init -backend=false` & `terraform validate` (config)
- `terraform init -backend=false` & `terraform validate` (guardduty)
- `terraform init -backend=false` & `terraform validate` (securityhub)


------
https://chatgpt.com/codex/tasks/task_e_68c368d65060832e8928128eaf0b1e01

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added deployable stacks for CloudTrail, AWS Config, GuardDuty, and Security Hub in ap-northeast-1.
  - Introduced configurable inputs with validation for environment, app name, region, and service options.
  - Exposed outputs: CloudTrail trail ARN and log bucket, Config recorder/channel names and aggregator ARN, GuardDuty detector ID, Security Hub finding aggregator ARN.
- Chores
  - Standardized provider versions and default resource tagging.
  - Enabled encrypted, lock-enabled remote Terraform state storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->