### PR TITLE
feat(dev): add dev root modules

### DIFF
--- a/infra/live/dev/ap-northeast-1/api/backend.tf
+++ b/infra/live/dev/ap-northeast-1/api/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key          = "state/api/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/dev/ap-northeast-1/api/main.tf
+++ b/infra/live/dev/ap-northeast-1/api/main.tf
@@ -1,0 +1,33 @@
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+  config = {
+    bucket = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key    = "state/vpc/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+data "terraform_remote_state" "waf" {
+  backend = "s3"
+  config = {
+    bucket = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key    = "state/waf/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+module "api" {
+  source            = "../../../../modules/ecs-alb-service"
+  service_name      = "api"
+  vpc_id            = data.terraform_remote_state.vpc.outputs.vpc_id
+  subnet_ids        = flatten(values(data.terraform_remote_state.vpc.outputs.private_subnet_ids_by_az))
+  container_image   = var.container_image
+  container_port    = var.container_port
+  desired_count     = var.desired_count
+  task_cpu          = var.task_cpu
+  task_memory       = var.task_memory
+  allowed_cidrs     = var.allowed_cidrs
+  health_check_path = var.health_check_path
+  waf_acl_arn       = data.terraform_remote_state.waf.outputs.web_acl_arn
+  tags              = var.tags
+}

--- a/infra/live/dev/ap-northeast-1/api/outputs.tf
+++ b/infra/live/dev/ap-northeast-1/api/outputs.tf
@@ -1,0 +1,14 @@
+output "alb_dns_name" {
+  description = "DNS name of the ALB"
+  value       = module.api.alb_dns_name
+}
+
+output "alb_zone_id" {
+  description = "Hosted zone ID of the ALB"
+  value       = module.api.alb_zone_id
+}
+
+output "service_security_group_id" {
+  description = "Security group ID for ECS tasks"
+  value       = module.api.service_security_group_id
+}

--- a/infra/live/dev/ap-northeast-1/api/provider.tf
+++ b/infra/live/dev/ap-northeast-1/api/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "dev"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/dev/ap-northeast-1/api/terraform.tfvars
+++ b/infra/live/dev/ap-northeast-1/api/terraform.tfvars
@@ -1,0 +1,15 @@
+env      = "dev"
+app_name = "minimal-gov-dev-api"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+container_image   = "nginx:latest"
+container_port    = 80
+desired_count     = 1
+task_cpu          = 256
+task_memory       = 512
+allowed_cidrs     = ["10.0.0.0/16"]
+health_check_path = "/"

--- a/infra/live/dev/ap-northeast-1/api/variable.tf
+++ b/infra/live/dev/ap-northeast-1/api/variable.tf
@@ -1,0 +1,46 @@
+variable "env" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "container_image" {
+  type = string
+}
+
+variable "container_port" {
+  type = number
+}
+
+variable "desired_count" {
+  type    = number
+  default = 1
+}
+
+variable "task_cpu" {
+  type = number
+}
+
+variable "task_memory" {
+  type = number
+}
+
+variable "allowed_cidrs" {
+  type = list(string)
+}
+
+variable "health_check_path" {
+  type    = string
+  default = "/"
+}

--- a/infra/live/dev/ap-northeast-1/dns/backend.tf
+++ b/infra/live/dev/ap-northeast-1/dns/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key          = "state/dns/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/dev/ap-northeast-1/dns/main.tf
+++ b/infra/live/dev/ap-northeast-1/dns/main.tf
@@ -1,0 +1,30 @@
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+  config = {
+    bucket = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key    = "state/vpc/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+data "terraform_remote_state" "api" {
+  backend = "s3"
+  config = {
+    bucket = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key    = "state/api/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+module "svc_dns" {
+  source    = "../../../../modules/route53-phz-service"
+  zone_name = var.zone_name
+  vpc_id    = data.terraform_remote_state.vpc.outputs.vpc_id
+  records = [{
+    name          = var.record_name
+    type          = "A"
+    alias_zone_id = data.terraform_remote_state.api.outputs.alb_zone_id
+    alias_name    = data.terraform_remote_state.api.outputs.alb_dns_name
+  }]
+  tags = var.tags
+}

--- a/infra/live/dev/ap-northeast-1/dns/outputs.tf
+++ b/infra/live/dev/ap-northeast-1/dns/outputs.tf
@@ -1,0 +1,4 @@
+output "zone_id" {
+  description = "ID of the private hosted zone"
+  value       = module.svc_dns.zone_id
+}

--- a/infra/live/dev/ap-northeast-1/dns/provider.tf
+++ b/infra/live/dev/ap-northeast-1/dns/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "dev"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/dev/ap-northeast-1/dns/terraform.tfvars
+++ b/infra/live/dev/ap-northeast-1/dns/terraform.tfvars
@@ -1,0 +1,10 @@
+env      = "dev"
+app_name = "minimal-gov-dev-dns"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+zone_name   = "svc.local"
+record_name = "api"

--- a/infra/live/dev/ap-northeast-1/dns/variable.tf
+++ b/infra/live/dev/ap-northeast-1/dns/variable.tf
@@ -1,0 +1,24 @@
+variable "env" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "zone_name" {
+  type = string
+}
+
+variable "record_name" {
+  type = string
+}

--- a/infra/live/dev/ap-northeast-1/ecr/backend.tf
+++ b/infra/live/dev/ap-northeast-1/ecr/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key          = "state/ecr/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/dev/ap-northeast-1/ecr/main.tf
+++ b/infra/live/dev/ap-northeast-1/ecr/main.tf
@@ -1,0 +1,11 @@
+module "ecr" {
+  source              = "../../../../modules/ecr-repository"
+  env                 = var.env
+  app_name            = var.app_name
+  region              = var.region
+  name                = var.name
+  keep_last_images    = var.keep_last_images
+  kms_key_arn         = var.kms_key_arn
+  pull_principal_arns = var.pull_principal_arns
+  tags                = var.tags
+}

--- a/infra/live/dev/ap-northeast-1/ecr/outputs.tf
+++ b/infra/live/dev/ap-northeast-1/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_url" {
+  description = "URL of the created ECR repository"
+  value       = module.ecr.repository_url
+}
+
+output "repository_arn" {
+  description = "ARN of the created ECR repository"
+  value       = module.ecr.repository_arn
+}

--- a/infra/live/dev/ap-northeast-1/ecr/provider.tf
+++ b/infra/live/dev/ap-northeast-1/ecr/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "dev"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/dev/ap-northeast-1/ecr/terraform.tfvars
+++ b/infra/live/dev/ap-northeast-1/ecr/terraform.tfvars
@@ -1,0 +1,11 @@
+env      = "dev"
+app_name = "minimal-gov-dev-ecr"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+name                = "app"
+keep_last_images    = 10
+pull_principal_arns = []

--- a/infra/live/dev/ap-northeast-1/ecr/variable.tf
+++ b/infra/live/dev/ap-northeast-1/ecr/variable.tf
@@ -1,0 +1,35 @@
+variable "env" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "name" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "keep_last_images" {
+  type    = number
+  default = 10
+}
+
+variable "kms_key_arn" {
+  type    = string
+  default = null
+}
+
+variable "pull_principal_arns" {
+  type    = list(string)
+  default = []
+}

--- a/infra/live/dev/ap-northeast-1/rds/backend.tf
+++ b/infra/live/dev/ap-northeast-1/rds/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key          = "state/rds/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/dev/ap-northeast-1/rds/main.tf
+++ b/infra/live/dev/ap-northeast-1/rds/main.tf
@@ -1,0 +1,50 @@
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+  config = {
+    bucket = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key    = "state/vpc/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+resource "aws_security_group" "db" {
+  name        = "db-sg"
+  description = "Database security group"
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  ingress {
+    description = "Allow DB access from VPC"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+module "db" {
+  source                 = "../../../../modules/rds"
+  name_prefix            = "dev"
+  subnet_ids             = [for az, ids in data.terraform_remote_state.vpc.outputs.private_subnet_ids_by_az : ids[0]]
+  vpc_security_group_ids = [aws_security_group.db.id]
+  engine                 = var.engine
+  engine_version         = var.engine_version
+  instance_class         = var.instance_class
+  allocated_storage      = var.allocated_storage
+  db_name                = var.db_name
+  username               = var.username
+  password               = var.password
+  multi_az               = var.multi_az
+  backup_retention_days  = var.backup_retention_days
+  skip_final_snapshot    = var.skip_final_snapshot
+  apply_immediately      = var.apply_immediately
+  tags                   = var.tags
+}

--- a/infra/live/dev/ap-northeast-1/rds/outputs.tf
+++ b/infra/live/dev/ap-northeast-1/rds/outputs.tf
@@ -1,0 +1,14 @@
+output "db_instance_endpoint" {
+  description = "Endpoint of the RDS instance"
+  value       = module.db.db_instance_endpoint
+}
+
+output "db_instance_identifier" {
+  description = "Identifier of the RDS instance"
+  value       = module.db.db_instance_identifier
+}
+
+output "security_group_id" {
+  description = "Security group ID for the database"
+  value       = aws_security_group.db.id
+}

--- a/infra/live/dev/ap-northeast-1/rds/provider.tf
+++ b/infra/live/dev/ap-northeast-1/rds/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "dev"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/dev/ap-northeast-1/rds/terraform.tfvars
+++ b/infra/live/dev/ap-northeast-1/rds/terraform.tfvars
@@ -1,0 +1,20 @@
+env      = "dev"
+app_name = "minimal-gov-dev-rds"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+db_name               = "app"
+username              = "dbadmin"
+password              = "DummyPass1234!"
+vpc_cidr              = "10.0.0.0/16"
+engine                = "postgres"
+engine_version        = "15"
+instance_class        = "db.t3.micro"
+allocated_storage     = 20
+multi_az              = false
+backup_retention_days = 7
+skip_final_snapshot   = true
+apply_immediately     = true

--- a/infra/live/dev/ap-northeast-1/rds/variable.tf
+++ b/infra/live/dev/ap-northeast-1/rds/variable.tf
@@ -1,0 +1,72 @@
+variable "env" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "db_name" {
+  type = string
+}
+
+variable "username" {
+  type = string
+}
+
+variable "password" {
+  type = string
+}
+
+variable "engine" {
+  type    = string
+  default = "postgres"
+}
+
+variable "engine_version" {
+  type    = string
+  default = "15"
+}
+
+variable "instance_class" {
+  type    = string
+  default = "db.t3.micro"
+}
+
+variable "allocated_storage" {
+  type    = number
+  default = 20
+}
+
+variable "multi_az" {
+  type    = bool
+  default = false
+}
+
+variable "backup_retention_days" {
+  type    = number
+  default = 7
+}
+
+variable "skip_final_snapshot" {
+  type    = bool
+  default = true
+}
+
+variable "apply_immediately" {
+  type    = bool
+  default = true
+}
+
+variable "vpc_cidr" {
+  type = string
+}

--- a/infra/live/dev/ap-northeast-1/vpc/backend.tf
+++ b/infra/live/dev/ap-northeast-1/vpc/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key          = "state/vpc/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/dev/ap-northeast-1/vpc/main.tf
+++ b/infra/live/dev/ap-northeast-1/vpc/main.tf
@@ -1,0 +1,9 @@
+module "dev_vpc" {
+  source                      = "../../../../modules/vpc-spoke"
+  vpc_name                    = "dev"
+  vpc_cidr                    = var.vpc_cidr
+  azs                         = var.azs
+  private_subnet_count_per_az = var.private_subnet_count_per_az
+  subnet_newbits              = var.subnet_newbits
+  tags                        = var.tags
+}

--- a/infra/live/dev/ap-northeast-1/vpc/outputs.tf
+++ b/infra/live/dev/ap-northeast-1/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the dev VPC"
+  value       = module.dev_vpc.vpc_id
+}
+
+output "private_subnet_ids_by_az" {
+  description = "Map of private subnet IDs by AZ"
+  value       = module.dev_vpc.private_subnet_ids_by_az
+}
+
+output "route_table_ids" {
+  description = "List of route table IDs"
+  value       = module.dev_vpc.route_table_ids
+}

--- a/infra/live/dev/ap-northeast-1/vpc/provider.tf
+++ b/infra/live/dev/ap-northeast-1/vpc/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "dev"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/dev/ap-northeast-1/vpc/terraform.tfvars
+++ b/infra/live/dev/ap-northeast-1/vpc/terraform.tfvars
@@ -1,0 +1,12 @@
+env      = "dev"
+app_name = "minimal-gov-dev-vpc"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+vpc_cidr                    = "10.0.0.0/16"
+azs                         = ["ap-northeast-1a", "ap-northeast-1c"]
+private_subnet_count_per_az = 2
+subnet_newbits              = 8

--- a/infra/live/dev/ap-northeast-1/vpc/variable.tf
+++ b/infra/live/dev/ap-northeast-1/vpc/variable.tf
@@ -1,0 +1,34 @@
+variable "env" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "vpc_cidr" {
+  type = string
+}
+
+variable "azs" {
+  type = list(string)
+}
+
+variable "private_subnet_count_per_az" {
+  type    = number
+  default = 2
+}
+
+variable "subnet_newbits" {
+  type    = number
+  default = 8
+}

--- a/infra/live/dev/ap-northeast-1/vpce/backend.tf
+++ b/infra/live/dev/ap-northeast-1/vpce/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key          = "state/vpce/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/dev/ap-northeast-1/vpce/main.tf
+++ b/infra/live/dev/ap-northeast-1/vpce/main.tf
@@ -1,0 +1,40 @@
+data "terraform_remote_state" "vpc" {
+  backend = "s3"
+  config = {
+    bucket = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key    = "state/vpc/terraform.tfstate"
+    region = "ap-northeast-1"
+  }
+}
+
+resource "aws_security_group" "vpce" {
+  name        = "vpce-sg"
+  description = "Security group for VPC endpoints"
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  ingress {
+    description = "Allow HTTPS from VPC"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = var.tags
+}
+
+module "vpce" {
+  source            = "../../../../modules/workload-vpce"
+  vpc_id            = data.terraform_remote_state.vpc.outputs.vpc_id
+  subnet_ids        = flatten(values(data.terraform_remote_state.vpc.outputs.private_subnet_ids_by_az))
+  security_group_id = aws_security_group.vpce.id
+  services          = var.services
+  tags              = var.tags
+}

--- a/infra/live/dev/ap-northeast-1/vpce/outputs.tf
+++ b/infra/live/dev/ap-northeast-1/vpce/outputs.tf
@@ -1,0 +1,4 @@
+output "endpoint_ids" {
+  description = "Map of created VPC endpoint IDs"
+  value       = module.vpce.endpoint_ids
+}

--- a/infra/live/dev/ap-northeast-1/vpce/provider.tf
+++ b/infra/live/dev/ap-northeast-1/vpce/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "dev"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/dev/ap-northeast-1/vpce/terraform.tfvars
+++ b/infra/live/dev/ap-northeast-1/vpce/terraform.tfvars
@@ -1,0 +1,10 @@
+env      = "dev"
+app_name = "minimal-gov-dev-vpce"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+vpc_cidr = "10.0.0.0/16"
+services = []

--- a/infra/live/dev/ap-northeast-1/vpce/variable.tf
+++ b/infra/live/dev/ap-northeast-1/vpce/variable.tf
@@ -1,0 +1,25 @@
+variable "env" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "services" {
+  type    = list(string)
+  default = []
+}
+
+variable "vpc_cidr" {
+  type = string
+}

--- a/infra/live/dev/ap-northeast-1/waf/backend.tf
+++ b/infra/live/dev/ap-northeast-1/waf/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket       = "minimal-gov-dev-backend-tfstate-ap-northeast-1-351277498040"
+    key          = "state/waf/terraform.tfstate"
+    region       = "ap-northeast-1"
+    encrypt      = true
+    use_lockfile = true
+  }
+}

--- a/infra/live/dev/ap-northeast-1/waf/main.tf
+++ b/infra/live/dev/ap-northeast-1/waf/main.tf
@@ -1,0 +1,6 @@
+module "waf" {
+  source      = "../../../../modules/waf-acl"
+  name        = var.name
+  allow_cidrs = var.allow_cidrs
+  tags        = var.tags
+}

--- a/infra/live/dev/ap-northeast-1/waf/outputs.tf
+++ b/infra/live/dev/ap-northeast-1/waf/outputs.tf
@@ -1,0 +1,9 @@
+output "web_acl_arn" {
+  description = "ARN of the created WAF Web ACL"
+  value       = module.waf.web_acl_arn
+}
+
+output "ip_set_arn" {
+  description = "ARN of the allow IP set"
+  value       = module.waf.ip_set_arn
+}

--- a/infra/live/dev/ap-northeast-1/waf/provider.tf
+++ b/infra/live/dev/ap-northeast-1/waf/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.9.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.9"
+    }
+  }
+}
+
+provider "aws" {
+  profile = "dev"
+  region  = var.region
+
+  default_tags {
+    tags = {
+      Application = var.app_name
+      Environment = var.env
+      ManagedBy   = "Terraform"
+      Region      = var.region
+    }
+  }
+}

--- a/infra/live/dev/ap-northeast-1/waf/terraform.tfvars
+++ b/infra/live/dev/ap-northeast-1/waf/terraform.tfvars
@@ -1,0 +1,10 @@
+env      = "dev"
+app_name = "minimal-gov-dev-waf"
+region   = "ap-northeast-1"
+
+tags = {
+  Project = "minimal-gov"
+}
+
+name        = "dev"
+allow_cidrs = ["10.0.0.0/16"]

--- a/infra/live/dev/ap-northeast-1/waf/variable.tf
+++ b/infra/live/dev/ap-northeast-1/waf/variable.tf
@@ -1,0 +1,24 @@
+variable "env" {
+  type = string
+}
+
+variable "app_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "name" {
+  type = string
+}
+
+variable "allow_cidrs" {
+  type = list(string)
+}

--- a/infra/modules/vpc-spoke/main.tf
+++ b/infra/modules/vpc-spoke/main.tf
@@ -1,5 +1,5 @@
-  locals {
-
+locals {
+  name_prefix = var.vpc_name != "" ? var.vpc_name : "spoke"
   # 総サブネット数（AZ 数 × AZ あたりのプライベートサブネット個数）
   total_private_subnets = length(var.azs) * var.private_subnet_count_per_az
 }
@@ -11,24 +11,24 @@ resource "aws_vpc" "this" {
   cidr_block           = var.vpc_cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
-  tags = var.tags
+  tags                 = var.tags
 }
 
 ###############################################
 # Subnet
 ###############################################
 resource "aws_subnet" "private" {
-  count                   = local.total_private_subnets
-  vpc_id                  = aws_vpc.this.id
+  count  = local.total_private_subnets
+  vpc_id = aws_vpc.this.id
 
   # azs = [a, c], per_az = 3 のとき、
   # index:0..5 に対して 0..2 は a、3..5 は c となるように割当
-  availability_zone       = element(var.azs, floor(count.index / var.private_subnet_count_per_az))
+  availability_zone = element(var.azs, floor(count.index / var.private_subnet_count_per_az))
 
   # 各サブネットの CIDR を連番で作成
-  cidr_block              = cidrsubnet(var.vpc_cidr, var.subnet_newbits, count.index)
+  cidr_block = cidrsubnet(var.vpc_cidr, var.subnet_newbits, count.index)
 
-  #public IP は自動付与しない
+  # public IP は自動付与しない
   map_public_ip_on_launch = false
 
   tags = merge(
@@ -72,4 +72,3 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private[count.index].id
 }
-


### PR DESCRIPTION
## Summary
- add ECR, VPC, VPCE, WAF, RDS, ECS service, and DNS root modules for dev environment
- allow vpc-spoke module to derive name prefix from `vpc_name`

## Testing
- `terraform init -backend=false && terraform validate` in `infra/live/dev/ap-northeast-1/ecr`
- `terraform init -backend=false && terraform validate` in `infra/live/dev/ap-northeast-1/vpc`
- `terraform init -backend=false && terraform validate` in `infra/live/dev/ap-northeast-1/vpce`
- `terraform init -backend=false && terraform validate` in `infra/live/dev/ap-northeast-1/waf`
- `terraform init -backend=false && terraform validate` in `infra/live/dev/ap-northeast-1/rds`
- `terraform init -backend=false && terraform validate` in `infra/live/dev/ap-northeast-1/api`
- `terraform init -backend=false && terraform validate` in `infra/live/dev/ap-northeast-1/dns`


------
https://chatgpt.com/codex/tasks/task_e_68c3689eccfc832eb000d065a66b7fbf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Provisioned a full dev stack in ap-northeast-1: VPC with private subnets, ECR repository, ECS-based API behind an ALB, WAF protection, and an RDS instance.
  * Added private DNS for the API and set up VPC endpoints.
  * Exposed key outputs (ALB DNS/zone, RDS endpoint, security groups, VPCE IDs) for easier integration.
* Chores
  * Enabled encrypted, locked remote Terraform state.
  * Standardized provider versions, profiles, regions, and default tagging.
  * Improved resource naming for subnets and route tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->