### PR TITLE
Add metadata inputs and tagging support to ECS Fargate module

### DIFF
--- a/infra/envs/dev/app/ecs/terragrunt.hcl
+++ b/infra/envs/dev/app/ecs/terragrunt.hcl
@@ -7,6 +7,16 @@ terraform {
 }
 
 inputs = {
+  # Metadata
+  env      = "dev"
+  app_name = "portfolio-app"
+  tags = {
+    Project     = "minimal-gov"
+    Environment = "dev"
+    ManagedBy   = "Terraform"
+  }
+
+  # Service settings
   service_name         = "portfolio-app"
   container_image      = "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/portfolio:latest"
   container_port       = 8080

--- a/infra/modules/ecs-fargate/README.md
+++ b/infra/modules/ecs-fargate/README.md
@@ -1,0 +1,39 @@
+# ECS Fargate Module
+
+このモジュールは、Fargate 上で動作するシンプルな ECS サービスを構築します。共通メタデータとして環境名やアプリケーション名、任意タグを受け取り、関連リソースに付与します。
+
+## Inputs
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `env` | `string` | yes | 環境名 (例: `dev`, `stg`, `prd`)。タスク定義の環境変数 `ENV` に設定されます。 |
+| `app_name` | `string` | yes | アプリケーション名。`Application` タグの値として利用します。 |
+| `tags` | `map(string)` | no | 追加で付与するタグ。セキュリティグループや CloudWatch Logs などモジュールが作成するリソースに設定され、`Application`/`Environment` タグに上書きでマージされます。 |
+| `service_name` | `string` | yes | ECS サービス名。関連するリソース名のプレフィックスとして利用します。 |
+| `container_image` | `string` | yes | タスクで使用するコンテナイメージ。 |
+| `container_port` | `number` | yes | コンテナがリッスンするポート番号。 |
+| `subnet_ids` | `list(string)` | yes | サービスを配置するサブネット ID の一覧。 |
+| `alb_target_group_arn` | `string` | yes | 紐付ける ALB ターゲットグループの ARN。 |
+| `security_groups` | `list(string)` | no | 追加で付与するセキュリティグループ ID。 |
+| `desired_count` | `number` | no | サービスの希望タスク数。デフォルトは `1`。 |
+
+## Example (Terragrunt)
+
+```hcl
+inputs = {
+  env      = "dev"
+  app_name = "portfolio-app"
+  tags = {
+    Project     = "minimal-gov"
+    Environment = "dev"
+    ManagedBy   = "Terraform"
+  }
+
+  service_name         = "portfolio-app"
+  container_image      = "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/portfolio:latest"
+  container_port       = 8080
+  subnet_ids           = dependency.vpc.outputs.private_subnets
+  alb_target_group_arn = dependency.alb.outputs.target_group_arn
+  security_groups      = [dependency.rds.outputs.sg_id]
+}
+```

--- a/infra/modules/ecs-fargate/main.tf
+++ b/infra/modules/ecs-fargate/main.tf
@@ -1,3 +1,10 @@
+locals {
+  resource_tags = merge({
+    Application = var.app_name
+    Environment = var.env
+  }, var.tags)
+}
+
 module "ecs_sg" {
   source  = "terraform-aws-modules/security-group/aws"
   version = "~> 5.0"
@@ -23,11 +30,15 @@ module "ecs_sg" {
       cidr_blocks = "0.0.0.0/0"
     }
   ]
+
+  tags = local.resource_tags
 }
 
 resource "aws_cloudwatch_log_group" "ecs" {
   name              = "/ecs/${var.service_name}"
   retention_in_days = 30
+
+  tags = local.resource_tags
 }
 
 module "ecs" {
@@ -35,6 +46,7 @@ module "ecs" {
   version = "~> 5.0"
 
   cluster_name = "${var.service_name}-cluster"
+  tags         = local.resource_tags
 
   services = {
     (var.service_name) = {
@@ -57,7 +69,7 @@ module "ecs" {
           environment = [
             {
               name  = "ENV"
-              value = "dev"
+              value = var.env
             }
           ]
 

--- a/infra/modules/ecs-fargate/variables.tf
+++ b/infra/modules/ecs-fargate/variables.tf
@@ -3,6 +3,22 @@ variable "service_name" {
   description = "ECS service name"
 }
 
+variable "env" {
+  type        = string
+  description = "Environment name (e.g. dev, stg, prd)"
+}
+
+variable "app_name" {
+  type        = string
+  description = "Application name for tagging"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags to apply to resources"
+}
+
 variable "container_image" {
   type        = string
   description = "Container image for ECS task"


### PR DESCRIPTION
## Summary
- add common metadata inputs (`env`, `app_name`, `tags`) to the ECS Fargate module
- propagate merged metadata tags to module resources and use the environment in the task definition
- document the new inputs and update the sample Terragrunt configuration

## Testing
- not run (terraform CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca3b6f9134832e9da1a1a56ece937f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment-aware configuration for the dev service, including standardized application and environment tags on related resources.
  * Dynamic container environment variable now aligns with the selected environment.
  * Consistent tagging applied across service resources (networking, logs, and compute) for easier identification and management.

* **Documentation**
  * Added module documentation outlining required inputs, tagging behavior, and an example configuration for typical usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->