### PR TITLE
Fix ECR terragrunt source path

### DIFF
--- a/infra/envs/dev/app/ecr/terragrunt.hcl
+++ b/infra/envs/dev/app/ecr/terragrunt.hcl
@@ -3,7 +3,7 @@ include {
 }
 
 terraform {
-  source = "../../../../modules/vpc"
+  source = "../../../../modules/ecr"
 }
 
 inputs = {


### PR DESCRIPTION
## Summary
- point the dev app ECR terragrunt configuration at the ecr module
- confirmed that the existing extra_tags input matches the module's tag map interface

## Testing
- `terragrunt run-all plan --terragrunt-non-interactive` *(fails: terragrunt not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3b491804832eac46c78b17d48fa4