### PR TITLE
Update TGW VPC attachment variables and examples

### DIFF
--- a/infra/envs/dev/network/tgw-attachment/terragrunt.hcl
+++ b/infra/envs/dev/network/tgw-attachment/terragrunt.hcl
@@ -11,10 +11,13 @@ dependencies {
 }
 
 inputs = {
-  transit_gateway_id          = "tgw-1234567890abcdef"
-  tgw_attachment_subnet_names = ["app-a", "app-c"]
+  transit_gateway_id = "tgw-1234567890abcdef"
 
   # VPC依存関係から参照
-  vpc_id  = dependency.vpc.outputs.vpc_id
-  subnets = dependency.vpc.outputs.subnet_ids
+  vpc_id   = dependency.vpc.outputs.vpc_id
+  vpc_name = "minimal-gov-dev-vpc"
+  subnet_ids = [
+    dependency.vpc.outputs.subnets["app-a"].id,
+    dependency.vpc.outputs.subnets["app-c"].id,
+  ]
 }

--- a/infra/modules/tgw-vpc-attachment/variables.tf
+++ b/infra/modules/tgw-vpc-attachment/variables.tf
@@ -44,14 +44,19 @@ variable "appliance_mode_support" {
   default = false
 }
 
-variable "transit_gateway_default_route_table_association" {
+variable "default_route_table_association" {
   type    = bool
   default = false
 }
 
-variable "transit_gateway_default_route_table_propagation" {
+variable "default_route_table_propagation" {
   type    = bool
   default = false
+}
+
+variable "vpc_name" {
+  description = "Name of the VPC to be used when tagging the attachment"
+  type        = string
 }
 
 variable "dns_support" {


### PR DESCRIPTION
## Summary
- rename the TGW VPC attachment module variables to match the implementation names
- add a vpc_name input so tags can include the associated VPC name
- refresh the Terragrunt example to use the current module interface, including the new variable

## Testing
- terraform fmt infra/modules/tgw-vpc-attachment *(fails: terraform not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3b44c1e4832eab5a4d39226ecb61