### PR TITLE
Update network endpoint terragrunt configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,3 +39,22 @@
 ├── image             # Architecture diagrams
 └── readme.md         # This file
 ```
+
+## Terragrunt Workflow
+
+ネットワークアカウントでは Terragrunt を利用してモジュール間の依存関係を解決しています。以下の手順で VPC モジュールとエンドポイントモジュールを組み合わせた `plan` を実行できます。
+
+1. Terragrunt をインストールします（例: `go install github.com/gruntwork-io/terragrunt@latest`）。
+2. AWS の認証情報とリージョンを環境変数に設定します。
+3. ネットワーク環境ディレクトリに移動します。
+   ```bash
+   cd infra/envs/network
+   ```
+4. 依存関係を含めた `plan` を実行します。`vpc` と `endpoint` の両方を対象にすることで、VPC 出力を Terragrunt の依存関係として解決しながら計画を確認できます。
+   ```bash
+   terragrunt run-all plan \
+     --terragrunt-include-dir vpc \
+     --terragrunt-include-dir endpoint
+   ```
+
+`terragrunt run-all plan` は依存関係の順序（VPC → Endpoint）に従って各モジュールの `plan` を実行します。`endpoint` モジュールでは `mock_outputs` を定義しているため、VPC が未適用の状態でも依存関係の解決が可能です。


### PR DESCRIPTION
## Summary
- point the network endpoint Terragrunt configuration at the local endpoint module
- wire Terragrunt dependencies to consume VPC outputs and surface missing tags
- document how to run Terragrunt plans for the network environment

## Testing
- `terragrunt plan` *(fails: remote state bucket minimal-gov-network-backend-tfstate-ap-northeast-1-854669817093 does not exist or credentials missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ca3b4c7c84832ea50426bed90e453c